### PR TITLE
Modify SpawnUtils.SpawnApplianceBlueprint<T> to remove unused id parameter

### DIFF
--- a/KitchenLib/src/Utils/SpawnUtils.cs
+++ b/KitchenLib/src/Utils/SpawnUtils.cs
@@ -34,7 +34,7 @@ namespace KitchenLib.Utils
 				return default(Entity);
 		}
 
-		public static Entity SpawnApplianceBlueprint<T>(int id, float priceModifier = 0f, int forcePrice = -1)
+		public static Entity SpawnApplianceBlueprint<T>(float priceModifier = 0f, int forcePrice = -1)
 		{
 			var appliance = CustomGDO.GetCustomAppliance<T>();
 			if (appliance == null)


### PR DESCRIPTION
I believe the id parameter is an accident, as it's unused in the body.