### PR TITLE
ID references for Processes, Appliances, Items

### DIFF
--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(os)=='Windows_NT'">
-    <PlateUpGameFolder>D:\Program Files (x86)\Steam\steamapps\common\PlateUp\PlateUp</PlateUpGameFolder>
+    <PlateUpGameFolder>C:\Program Files (x86)\Steam\steamapps\common\PlateUp\PlateUp</PlateUpGameFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(os)=='UNIX'">
@@ -17,6 +17,7 @@
     <Reference Include="Controllers">
       <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\Controllers.dll</HintPath>
     </Reference>
+	
     <Reference Include="MelonLoader">
       <HintPath>$(PlateUpGameFolder)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
@@ -52,6 +53,9 @@
     </Reference>
     <Reference Include="Unity.Mathematics">
       <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\Unity.Mathematics.dll</HintPath>
+    </Reference>
+	<Reference Include="UnityEngine.ImageConversionModule">
+      <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="Sirenix.Serialization">
       <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\Sirenix.Serialization.dll</HintPath>

--- a/KitchenLib/src/Reference/ApplianceReference.cs
+++ b/KitchenLib/src/Reference/ApplianceReference.cs
@@ -1,0 +1,516 @@
+﻿namespace KitchenLib.Reference
+{
+    public class ApplianceReference
+    {
+        /*
+        string s = string.Empty;
+		foreach (Appliance appliance in gameData.Get<Appliance>())
+		{
+			s+= $"public const int {((string.IsNullOrEmpty(appliance.Name) ?appliance.name : appliance.Name)).Replace(" ","").Replace("-",""} = {appliance.ID};\n\n";
+		}
+		Mod.Log(s);
+        */
+
+        public const int HeatedMixer = 505496455;
+
+        public const int ConveyorMixer = -1357906425;
+
+        public const int RapidMixer = -1440053805;
+
+        public const int Mixer = 1329097317;
+
+        public const int Supplies = -1013770159;
+
+        public const int CompactorBin = 2127051779;
+
+        public const int ComposterBin = -1632826946;
+
+        public const int ExpandedBin = -1855909480;
+
+        public const int StarterBin = 481495292;
+
+        public const int Bin = 1551609169;
+
+        public const int FireExtinguisher = 1286554202;
+
+        public const int FloorBuffer = 1351951642;
+
+        public const int KitchenFloorProtector = 1765889988;
+
+        public const int FastMop = -1495393751;
+
+        public const int LastingMop = 1776760557;
+
+        public const int Mop = -1993346570;
+
+        public const int RobotBuffer = -1723340146;
+
+        public const int RobotMop = -2147057861;
+
+        public const int CoffeeMachine = -1609758240;
+
+        public const int ColouringBookStand = -17368064;
+
+        public const int Conveyor = 1973114260;
+
+        public const int Combiner = -1906799936;
+
+        public const int SmartGrabber = -1238047163;
+
+        public const int Grabber = -1029710921;
+
+        public const int Portioner = -1462602185;
+
+        public const int Counter = -1248669347;
+
+        public const int KneadingCounter = 1365340297;
+
+        public const int Workstation = -1573577293;
+
+        public const int AffordableBin = 620400448;
+
+        public const int GumballMachine = 1830133512;
+
+        public const int NeonSign = 1724963734;
+
+        public const int NeonSign2 = 371247235;
+
+        public const int CeilingLight = 230540973;
+
+        public const int StockPicture = -1472471467;
+
+        public const int DirtyFloorSign = -2108088224;
+
+        public const int Barrel = 1569358344;
+
+        public const int Bookcase = -60168847;
+
+        public const int Dartboard = -1941237931;
+
+        public const int Fireplace = -441525746;
+
+        public const int Rug = 591400026;
+
+        public const int WallLight = -1628995120;
+
+        public const int Banner = -1380985631;
+
+        public const int ChristmasTree = 1797739089;
+
+        public const int FairyLights = -4737636;
+
+        public const int Candelabra = -13481890;
+
+        public const int Chandelier = 1233091186;
+
+        public const int PreciousFlower = -1180623135;
+
+        public const int ClassicalGlobe = 642318074;
+
+        public const int Painting = -1486785449;
+
+        public const int Rug2 = 2076966627;
+
+        public const int Statue = -972644436;
+
+        public const int BrandMascot = 1551024733;
+
+        public const int TidyPlant = -1339970600;
+
+        public const int CeilingLight2 = 908498444;
+
+        public const int AbstractLamp = 744277037;
+
+        public const int Vase = 531866927;
+
+        public const int Indoorfountain = 1220439284;
+
+        public const int CalmPainting = 668664567;
+
+        public const int Plant = 756364626;
+
+        public const int Rug3 = -648349801;
+
+        public const int DrinkTap = -1506601664;
+
+        public const int WineBarrel = -2100580689;
+
+        public const int Dumbwaiter = 532998682;
+
+        public const int Fryer = 892856538;
+
+        public const int Beehive = -544237849;
+
+        public const int FlowerSpawn = 188952245;
+
+        public const int GasLimiter = 1921027834;
+
+        public const int GasOverride = -770041014;
+
+        public const int DangerHob = -1448690107;
+
+        public const int SafetyHob = 1266458729;
+
+        public const int StarterHob = 1154757341;
+
+        public const int Hob = 862493270;
+
+        public const int ManualHob = -441141351;
+
+        public const int TutorialHob = 805530854;
+
+        public const int BookingsStand = -60938940;
+
+        public const int HostingStand = -63118559;
+
+        public const int DisplayStand = -1813414500;
+
+        public const int BuffedFloor = 1630557157;
+
+        public const int MessCustomer1 = -1324288299;
+
+        public const int MessCustomer2 = -374077567;
+
+        public const int MessCustomer3 = 147181555;
+
+        public const int MessKitchen1 = 31731938;
+
+        public const int MessKitchen2 = 1419995156;
+
+        public const int MessKitchen3 = 34773971;
+
+        public const int MopWaterLong = -1424385600;
+
+        public const int MopWater = 377065033;
+
+        public const int Nameplate = -483535085;
+
+        public const int BlueprintLetter = 1553046198;
+
+        public const int Blueprint = 1063254979;
+
+        public const int FlooringApplicator = 1732122842;
+
+        public const int Parcel = -1936421857;
+
+        public const int WallpaperApplicator = 2041631136;
+
+        public const int AccountingDesk = 949631021;
+
+        public const int BlueprintCabinet = -571205127;
+
+        public const int CopyingDesk = -729493805;
+
+        public const int DiscountDesk = -272437832;
+
+        public const int DiscountDesk2 = 1586911545;
+
+        public const int BlueprintDesk = 1446975727;
+
+        public const int ResearchDesk = 1139247360;
+
+        public const int BookingDesk = 238041352;
+
+        public const int ExtraLife = -1817838704;
+
+        public const int FastFoodTerminal = 136867583;
+
+        public const int SpecialsTerminal = -246383526;
+
+        public const int OrderingTerminal = -1610332021;
+
+        public const int DoubleOven = 944301512;
+
+        public const int Microwave = -1311702572;
+
+        public const int Oven = -1068749602;
+
+        public const int Balloons = 1147639502;
+
+        public const int BirthdayBanner = -71664252;
+
+        public const int Piano = -326328571;
+
+        public const int Apples = -905438738;
+
+        public const int Beans = 1807525572;
+
+        public const int Broccoli = -1573812073;
+
+        public const int BurgerBuns = 759552160;
+
+        public const int Patties = 385684499;
+
+        public const int Carrots = -452101383;
+
+        public const int Cheese = -117339838;
+
+        public const int ChristmasCrackers = 303858729;
+
+        public const int Eggs = 961148621;
+
+        public const int Fish = -1735137431;
+
+        public const int Fish2 = -609358791;
+
+        public const int Flour = 925796718;
+
+        public const int Hotdogbun = -1132411297;
+
+        public const int HotDogs = 1799769627;
+
+        public const int IceCream = -1533430406;
+
+        public const int ExtraKetchup = -965827229;
+
+        public const int Lettuce = 1193867305;
+
+        public const int Meat = -484165118;
+
+        public const int Mushrooms = -1097889139;
+
+        public const int ExtraMustard = -117356585;
+
+        public const int Nuts = 1834063794;
+
+        public const int Oil = -1963699221;
+
+        public const int Olives = -1434800013;
+
+        public const int Onion = -2042103798;
+
+        public const int Potato = 44541785;
+
+        public const int Rice = -1201769154;
+
+        public const int Thickcutmeat = -1507801323;
+
+        public const int Thincutmeat = 1800865634;
+
+        public const int Tomato = -712909563;
+
+        public const int Turkey = -1506824829;
+
+        public const int Wine = -1353971407;
+
+        public const int BrokenEntity = -101564005;
+
+        public const int FireEntity = -897970831;
+
+        public const int Counter2 = -996680732;
+
+        public const int PracticeModeTrigger = 946079892;
+
+        public const int RerollShopTrigger = 1171429989;
+
+        public const int TutorialTrigger = 161402590;
+
+        public const int AutoPlater = 739504637;
+
+        public const int DishRack = 1653145961;
+
+        public const int DishRack2 = 434150763;
+
+        public const int ItemSourceReservation = 1270423542;
+
+        public const int ItemSource = -1474018107;
+
+        public const int StarterPlates = 380220741;
+
+        public const int Plates = 1313469794;
+
+        public const int PotStack = -957949759;
+
+        public const int ServingBoards = 235423916;
+
+        public const int Woks = 314862254;
+
+        public const int AlpineGround = -1291027873;
+
+        public const int AlpineTree = -214921468;
+
+        public const int Bush = -2135829561;
+
+        public const int Cobblestone = -372462424;
+
+        public const int CountrysideGround = 933445633;
+
+        public const int Flower = -1555334152;
+
+        public const int Flowerbed = 1980900762;
+
+        public const int LogWall = -1265562836;
+
+        public const int OutdoorMovementBlocker = -2046940874;
+
+        public const int Rock = -923570273;
+
+        public const int InternalWallPiece = -488268556;
+
+        public const int StreetPiece = -548432204;
+
+        public const int WallPiece = -758567246;
+
+        public const int Tree = 532701855;
+
+        public const int Freezer = -1857890774;
+
+        public const int FrozenPrepStation = -759808000;
+
+        public const int PrepStation = 1656358740;
+
+        public const int Rack = -262439022;
+
+        public const int StorageCupboard = 1890408483;
+
+        public const int Breadsticks = 639111696;
+
+        public const int CandleBox = 1358522063;
+
+        public const int FlowerPot = 221442949;
+
+        public const int Napkins = 1528688658;
+
+        public const int SharpCutlery = 2080633647;
+
+        public const int SpecialsMenu = 446555792;
+
+        public const int Chair = 938247786;
+
+        public const int CoffeeTable = 1648733244;
+
+        public const int Chair2 = -1979922052;
+
+        public const int BarTable = -3721951;
+
+        public const int TableSimpleCloth = -34659638;
+
+        public const int MetalTable = -203679687;
+
+        public const int TableFancyCloth = -2019409936;
+
+        public const int DiningTable = 209074140;
+
+        public const int RollingPin = 1738351766;
+
+        public const int ScrubbingBrush = 624465484;
+
+        public const int SharpKnife = 2023704259;
+
+        public const int Trainers = 723626409;
+
+        public const int Wellies = 1796077718;
+
+        public const int WorkBoots = 230848637;
+
+        public const int TrayStand = 1129858275;
+
+        public const int DishWasher = -823922901;
+
+        public const int WashBasin = -214126192;
+
+        public const int Sink = 1083874952;
+
+        public const int PowerSink = 1467371088;
+
+        public const int SoakingSink = 1860904347;
+
+        public const int StarterSink = -266993023;
+
+        public const int WheelieBin = 2073091578;
+
+        public const int Bed = -469149429;
+
+        public const int InteractionProxy = 834743908;
+
+        public const int UnoccupiedRoomIndicator = 951367272;
+
+        public const int CardViewer = 1771016910;
+
+        public const int ContractPedestal = -2122624266;
+
+        public const int ContractSource = -404095277;
+
+        public const int Projector = -1949016360;
+
+        public const int ScrapFranchise = -581219245;
+
+        public const int ContractsRoomLocked = -148578487;
+
+        public const int ExpGrant = -1125517450;
+
+        public const int GarageDecorations = -233558851;
+
+        public const int GarageDivider = -342718019;
+
+        public const int GarageShelf = 174737401;
+
+        public const int LoadoutPedestal = 310022384;
+
+        public const int WorkshopActivator = -1425710426;
+
+        public const int WorkshopCraftingOutput = -1807971648;
+
+        public const int WorkshopCraftingSlot = 268640447;
+
+        public const int WorkshopFence = 1199575543;
+
+        public const int WorkshopGate = -1451048989;
+
+        public const int WorkshopMachine = -1820794030;
+
+        public const int AnimalBowl = 871235082;
+
+        public const int AnimalFakeSeat = 387240739;
+
+        public const int Bin2 = 1159228054;
+
+        public const int KitchenTutorial = -626547002;
+
+        public const int DrawingBoardVisual = 359655899;
+
+        public const int FoodPedestalFranchise = -232172209;
+
+        public const int FoodPedestal = -1528441435;
+
+        public const int FoodSource = 564388954;
+
+        public const int MapPedestalSeeded = 1363960331;
+
+        public const int MapPedestal = -760874610;
+
+        public const int MapSource = 1823459359;
+
+        public const int OfficeDesk = 1659152562;
+
+        public const int SeedRunIndicator = 477050702;
+
+        public const int SeededRunSource = 1485375733;
+
+        public const int SeededRunVisual = -1114059052;
+
+        public const int BedroomColourSelector = -62256073;
+
+        public const int BedroomOutfitSelector = -1518462324;
+
+        public const int ProfileEditorTrigger = -1260306608;
+
+        public const int ReloadCrash = 1425494045;
+
+        public const int WorkshopRoomLocked = 1010867759;
+
+        public const int BuilderFloor = -720353319;
+
+        public const int CardSelector = -1997868587;
+
+        public const int ConfirmCreateText = -1920103064;
+
+        public const int TutorialFloor = -1235624607;
+
+        public const int ResearchExitText = -872135723;
+
+        public const int ResearchableUpgrade = -1879606524;
+
+        public const int UpgradeKit = -26827118;
+    }
+}

--- a/KitchenLib/src/Reference/ItemReference.cs
+++ b/KitchenLib/src/Reference/ItemReference.cs
@@ -1,0 +1,479 @@
+﻿namespace KitchenLib.Reference
+{
+    public class ItemReference
+    {
+        /*
+        string s = string.Empty;
+		foreach (Item item in gameData.Get<Item>())
+		{
+		    s += $"public const int {(item.name).Replace(" ", "").Replace("-","")} = {item.ID};\n\n";
+		}
+        */
+
+        public const int BeansCooked = 1286433124;
+
+        public const int BeansIngredient = 75221795;
+
+        public const int BeansRawPot = 1921097327;
+
+        public const int BeansServing = 2138118944;
+
+        public const int BreadBaked = 1867438686;
+
+        public const int BreadSlice = 306959510;
+
+        public const int BreadToast = 428559718;
+
+        public const int BreakfastPlated = 1754241573;
+
+        public const int EggCooked = 1324261001;
+
+        public const int BurgerPlated = 884392267;
+
+        public const int BurgerUnplated = 417685193;
+
+        public const int BurgerBun = 1756808590;
+
+        public const int BurgerPattyCooked = 687585830;
+
+        public const int BurgerPattyRaw = 1150879908;
+
+        public const int CondimentKetchup = 1075930689;
+
+        public const int CondimentMustard = 1114203942;
+
+        public const int HotdogCooked = 248200024;
+
+        public const int HotdogPlated = 1702578261;
+
+        public const int HotdogRaw = 1702717896;
+
+        public const int HotdogUnplated = 1134979829;
+
+        public const int HotdogBun = 756326364;
+
+        public const int ChristmasCracker = 749675166;
+
+        public const int NutMixtureBaked = 1945246136;
+
+        public const int NutMixturePortion = 1294491269;
+
+        public const int NutMixture = 1515496760;
+
+        public const int NutRoastPlated = 1934880099;
+
+        public const int NutsChopped = 2100850612;
+
+        public const int NutsIngredient = 609827370;
+
+        public const int TurkeyBurned = 1755371377;
+
+        public const int TurkeyCooked = 1568853395;
+
+        public const int TurkeyIngredient = 1831502471;
+
+        public const int TurkeyPlated = 1792757441;
+
+        public const int TurkeySlice = 914826716;
+
+        public const int Contract = 1778270917;
+
+        public const int Crate = 2065950566;
+
+        public const int DishChoice = 509800267;
+
+        public const int FranchiseCardSet = 1677093775;
+
+        public const int LayoutMap = 70952701;
+
+        public const int NonLoadoutCrate = 620886547;
+
+        public const int BirthdayCake = 1950713115;
+
+        public const int CakeSlice = 1842891105;
+
+        public const int ColouringBook = 1843738466;
+
+        public const int CheeseBoardServing = 1639948793;
+
+        public const int ServingBoard = 626784042;
+
+        public const int CoffeeCupCoffee = 1293050650;
+
+        public const int CoffeeCup = 364023067;
+
+        public const int IceCreamChocolate = 502129042;
+
+        public const int IceCreamServing = 1307479546;
+
+        public const int IceCreamStrawberry = 186895094;
+
+        public const int IceCreamVanilla = 1570518340;
+
+        public const int BeerMug = 369328905;
+
+        public const int WineBottle = 1387195911;
+
+        public const int CrabCakeEgged = 1195805465;
+
+        public const int CrabCakeFloured = 1914908152;
+
+        public const int CrabCakePlated = 1939124686;
+
+        public const int CrabChopped = 1678080982;
+
+        public const int CrabCookedCake = 2007852530;
+
+        public const int CrabRaw = 1452580334;
+
+        public const int FishBlueFried = 454058921;
+
+        public const int FishBluePlated = 536781335;
+
+        public const int FishBlueRaw = 1592653566;
+
+        public const int FishBurned = 9768533;
+
+        public const int FishFilletCooked = 505249062;
+
+        public const int FishFilletPlated = 1011454010;
+
+        public const int FishFilletRaw = 2145487392;
+
+        public const int FishFillet = 1607298447;
+
+        public const int FishOysterPlated = 403539963;
+
+        public const int FishOysterRaw = 216090589;
+
+        public const int FishOysterShucked = 920494794;
+
+        public const int FishPinkFried = 411057095;
+
+        public const int FishPinkPlated = 1608542149;
+
+        public const int FishPinkRaw = 1244918234;
+
+        public const int FishSpecialExtraChoice1 = 107399665;
+
+        public const int FishSpecialExtraChoice2 = 2113587247;
+
+        public const int AppleSlices = 252763172;
+
+        public const int Apple = 681117884;
+
+        public const int BurnedBread = 263299406;
+
+        public const int BurnedFood = 1960690485;
+
+        public const int Carrot = 1944015682;
+
+        public const int CookedApple = 617153544;
+
+        public const int Dough = 1296980128;
+
+        public const int EggCracked = 378690159;
+
+        public const int Egg = 1755299639;
+
+        public const int Flour = 1378842682;
+
+        public const int Mayonnaise = 564003642;
+
+        public const int MeatThick = 45632521;
+
+        public const int MeatThin = 1256038534;
+
+        public const int Meat = 1306214641;
+
+        public const int MushroomChopped = 2093899333;
+
+        public const int MushroomCookedWrapped = 336580972;
+
+        public const int Mushroom = 313161428;
+
+        public const int OilIngredient = 1853193980;
+
+        public const int Oil = 1900989960;
+
+        public const int Onion = 201067776;
+
+        public const int PotatoChoppedCooked = 1399719685;
+
+        public const int PotatoChoppedPotCooked = 2010203194;
+
+        public const int PotatoChoppedPotRaw = 706413527;
+
+        public const int PotatoChopped = 35611244;
+
+        public const int Potato = 1972529263;
+
+        public const int Water = 1657174953;
+
+        public const int BinBag = 1660145659;
+
+        public const int DisposableRubbish = 1931641307;
+
+        public const int FlammableBinBag = 895813906;
+
+        public const int Menu = 1491776620;
+
+        public const int TableBlockRubbish = 1863985141;
+
+        public const int PieAppleCooked = 82666420;
+
+        public const int PieAppleRaw = 642148977;
+
+        public const int PieDessertPlated = 1605432111;
+
+        public const int PieMeatCooked = 1030798878;
+
+        public const int PieMeatRawBlindBaked = 671227602;
+
+        public const int PieMeatRaw = 469170277;
+
+        public const int PieMushroomCooked = 280553412;
+
+        public const int PieMushroomRawBlindBaked = 415541985;
+
+        public const int PieMushroomRaw = 427507425;
+
+        public const int PiePlated = 861630222;
+
+        public const int PieVegetableCooked = 1612932608;
+
+        public const int PieVegetableRawBlindBaked = 1701915481;
+
+        public const int PieVegetableRaw = 1428220456;
+
+        public const int PieCrustCooked = 1963815217;
+
+        public const int PieCrustRaw = 164600160;
+
+        public const int CheeseGrated = 263830100;
+
+        public const int CheeseWrappedCooked = 369505908;
+
+        public const int Cheese = 755280170;
+
+        public const int PizzaBurned = 1063655063;
+
+        public const int PizzaCooked = 1196800934;
+
+        public const int PizzaCrust = 48499881;
+
+        public const int PizzaPlated = 1087205958;
+
+        public const int PizzaRaw = 445221203;
+
+        public const int PizzaSlice = 938942828;
+
+        public const int TomatoSauce = 1317168923;
+
+        public const int ForgetMeNot = 401734755;
+
+        public const int Leave = 1310307277;
+
+        public const int Patience = 808698209;
+
+        public const int RoastLegCooked = 1801513942;
+
+        public const int RoastLegDepleted = 2002011353;
+
+        public const int RoastLegRaw = 1574653982;
+
+        public const int RoastLegServed = 166749992;
+
+        public const int LettuceChopped = 1397390776;
+
+        public const int Lettuce = 65594226;
+
+        public const int Olive = 892659864;
+
+        public const int OnionChopped = 1252408744;
+
+        public const int OnionCookedWrapped = 1633089577;
+
+        public const int SaladApplePlated = 599544171;
+
+        public const int SaladPlated = 1835015742;
+
+        public const int SaladPotatoPlated = 2053442418;
+
+        public const int TomatoChopped = 853757044;
+
+        public const int Tomato = 1242961771;
+
+        public const int BrothCookedOnion = 69847810;
+
+        public const int BrothRawOnion = 1370203151;
+
+        public const int SauceMushroomCooked = 65943925;
+
+        public const int SauceMushroomPortion = 1217105161;
+
+        public const int SauceMushroomRaw = 2105805937;
+
+        public const int SauceRedCooked = 1690253467;
+
+        public const int SauceRedPortion = 285798592;
+
+        public const int SauceRedRaw = 1289839594;
+
+        public const int BroccoliChopped = 748471091;
+
+        public const int BroccoliCookedPot = 98665743;
+
+        public const int BroccoliPot = 2141493703;
+
+        public const int BroccoliRaw = 1774883004;
+
+        public const int BroccoliServing = 1520921913;
+
+        public const int ChipsCooked = 259844528;
+
+        public const int BoiledPotatoCooked = 1965870011;
+
+        public const int BoiledPotatoMashed = 1341614392;
+
+        public const int BoiledPotatoRaw = 735644169;
+
+        public const int BoiledPotatoServing = 107345299;
+
+        public const int OnionRingsCooked = 1086687302;
+
+        public const int OnionRingsRaw = 1818895897;
+
+        public const int ServedSoupCarrot = 409276704;
+
+        public const int ServedSoupMeat = 1684936685;
+
+        public const int ServedSoupTomato = 894680043;
+
+        public const int SoupCarrotCooked = 1582466042;
+
+        public const int SoupCarrotRaw = 1361723814;
+
+        public const int SoupChoppedCarrotRaw = 1655490768;
+
+        public const int SoupChoppedMeatRaw = 2043533161;
+
+        public const int SoupChoppedTomatoRaw = 996662132;
+
+        public const int SoupDepleted = 1859809622;
+
+        public const int SoupMeatCooked = 1284423669;
+
+        public const int SoupMeatRaw = 1064697910;
+
+        public const int SoupRefilled = 719587509;
+
+        public const int SoupTomatoCooked = 1752228187;
+
+        public const int SoupTomatoRaw = 1863787598;
+
+        public const int SteakBurned = 320607572;
+
+        public const int SteakMedium = 744193417;
+
+        public const int SteakPlated = 1034349623;
+
+        public const int SteakRare = 1936140106;
+
+        public const int SteakWelldone = 1631681807;
+
+        public const int ThickSteakBurned = 958173724;
+
+        public const int ThickSteakMedium = 283606362;
+
+        public const int ThickSteakPlated = 1067846341;
+
+        public const int ThickSteakRare = 510353055;
+
+        public const int ThickSteakWelldone = 623804310;
+
+        public const int ThinSteakBurned = 469714996;
+
+        public const int ThinSteakMedium = 1645212811;
+
+        public const int ThinSteakPlated = 1173464355;
+
+        public const int ThinSteakRare = 1720486713;
+
+        public const int ThinSteakWelldone = 989359657;
+
+        public const int BroccoliChoppedContainerCooked = 1453647256;
+
+        public const int CarrotChoppedContainerCooked = 1406021079;
+
+        public const int CarrotChopped = 830135945;
+
+        public const int MeatChoppedContainerCooked = 1018018897;
+
+        public const int MeatChopped = 1005005768;
+
+        public const int RiceContainerCooked = 1928939081;
+
+        public const int Rice = 1271508828;
+
+        public const int StirFryCooked = 150639636;
+
+        public const int StirFryPlated = 361808208;
+
+        public const int StirFryRaw = 1475451665;
+
+        public const int WokBurned = 1770849684;
+
+        public const int Wok = 2135410839;
+
+        public const int Breadsticks = 44050480;
+
+        public const int Candle = 731135737;
+
+        public const int Napkin = 834566246;
+
+        public const int SharpCutlery = 269092883;
+
+        public const int SpecialsMenu = 538929686;
+
+        public const int TestCombineItem1 = 1453292775;
+
+        public const int TestCombineItem2 = 1135389096;
+
+        public const int TestItemGroup = 26858422;
+
+        public const int TestNonCombineItem = 587882643;
+
+        public const int FireExtinguisher = 241697184;
+
+        public const int FloorBuffer = 864849315;
+
+        public const int RollingPin = 2110926326;
+
+        public const int ScrubbingBrush = 110929446;
+
+        public const int SharpKnife = 670427032;
+
+        public const int MopFast = 2083359821;
+
+        public const int MopLasting = 819389746;
+
+        public const int Mop = 1142792325;
+
+        public const int PlateDirtySoaked = 1882569246;
+
+        public const int PlateDirty = 1517992271;
+
+        public const int Plate = 793377380;
+
+        public const int PotDirty = 1026000491;
+
+        public const int Pot = 486398094;
+
+        public const int SupplyBox = 601076588;
+
+        public const int Tray = 869580494;
+
+        public const int ResearchFlask = 56610526;
+    }
+}

--- a/KitchenLib/src/Reference/ProcessReference.cs
+++ b/KitchenLib/src/Reference/ProcessReference.cs
@@ -1,6 +1,6 @@
 ﻿namespace KitchenLib.Reference
 {
-    internal class Process
+    internal class ProcessReference
     {
         /*
         string s = string.Empty;

--- a/KitchenLib/src/Reference/ProcessReference.cs
+++ b/KitchenLib/src/Reference/ProcessReference.cs
@@ -1,6 +1,6 @@
 ﻿namespace KitchenLib.Reference
 {
-    internal class ProcessReference
+    public class ProcessReference
     {
         /*
         string s = string.Empty;

--- a/KitchenLib/src/Reference/ProcessReference.cs
+++ b/KitchenLib/src/Reference/ProcessReference.cs
@@ -2,6 +2,15 @@
 {
     internal class Process
     {
+        /*
+        string s = string.Empty;
+		foreach (Process process in gameData.Get<Process>())
+		{
+			s+= $"public const int {((string.IsNullOrEmpty(process.Name) ? process.name : process.Name)).Replace(" ","").Replace("-",""} = {process.ID};\n\n";
+		}
+		Mod.Log(s);
+        */
+
         public const int Chop = 2087693779;
 
         public const int CleanSoak = -2048664109;

--- a/KitchenLib/src/Reference/ProcessReference.cs
+++ b/KitchenLib/src/Reference/ProcessReference.cs
@@ -1,0 +1,31 @@
+﻿namespace KitchenLib.Reference
+{
+    internal class Process
+    {
+        public const int Chop = 2087693779;
+
+        public const int CleanSoak = -2048664109;
+
+        public const int Clean = 620897674;
+
+        public const int Cook = 1972879238;
+
+        public const int ExtinguishFire = -2063819574;
+
+        public const int FillCoffee = -1316622579;
+
+        public const int Knead = -523839730;
+
+        public const int BringNewCustomer = 298778045;
+
+        public const int Copy = -1622218557;
+
+        public const int Upgrade = 742419440;
+
+        public const int ChairInteraction = -1677305898;
+
+        public const int ReqiureOven = -1706154991;
+
+        public const int Purchase = 623753606;
+    }
+}

--- a/KitchenLib/src/Utils/GDOUtils.cs
+++ b/KitchenLib/src/Utils/GDOUtils.cs
@@ -7,22 +7,29 @@ namespace KitchenLib.Utils
 	{
 		private static Dictionary<int, Appliance> appliances = new Dictionary<int, Appliance>();
 		private static Dictionary<int, Item> items = new Dictionary<int, Item>();
-		private static Dictionary<string, Process> processes = new Dictionary<string, Process>();
+		private static Dictionary<int, Process> processes = new Dictionary<int, Process>();
+
+		private static Dictionary<string, Process> processesNamed = new Dictionary<string, Process>();
+
 		private static Dictionary<string, Item.ItemProcess> customItemProcesses = new Dictionary<string, Item.ItemProcess>();
 		private static Dictionary<string, Appliance.ApplianceProcesses> customApplianceProcesses = new Dictionary<string, Appliance.ApplianceProcesses>();
 
 		public static void SetupGDOIndex(GameData gameData)
 		{
 			foreach (Item item in gameData.Get<Item>())
+			{
 				GDOUtils.items.Add(item.ID, item);
+			}
 
 			foreach (Appliance appliance in gameData.Get<Appliance>())
+			{
 				GDOUtils.appliances.Add(appliance.ID, appliance);
+			}
 
 			foreach (Process process in gameData.Get<Process>())
 			{
-				//Mod.Log(process.ID + " - " + process.name);
-				GDOUtils.processes.Add(process.name, process);
+				GDOUtils.processes.Add(process.ID, process);
+				GDOUtils.processesNamed.Add(process.name, process);
 			}
 		}
 
@@ -38,9 +45,16 @@ namespace KitchenLib.Utils
 			return item;
 		}
 
+
+		public static Process GetExistingProcess(int id)
+		{
+			processes.TryGetValue(id, out Process process);
+			return process;
+		}
+
 		public static Process GetExistingProcess(string name)
 		{
-			processes.TryGetValue(name, out Process process);
+			processesNamed.TryGetValue(name, out Process process);
 			return process;
 		}
 
@@ -65,6 +79,5 @@ namespace KitchenLib.Utils
 		{
 			customApplianceProcesses.Add(name, process);
 		}
-
 	}
 }

--- a/KitchenLib/src/Utils/ResourceUtils.cs
+++ b/KitchenLib/src/Utils/ResourceUtils.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+
+namespace KitchenLib.Utils
+{
+
+    public class ResourceUtils
+    {
+        public static Texture2D LoadTextureRaw(byte[] file)
+        {
+            if (file.Count() > 0)
+            {
+                Texture2D Tex2D = new Texture2D(2, 2);
+                if (Tex2D.LoadImage(file))
+                {
+                    return Tex2D;
+                }
+            }
+            return null;
+        }
+
+        public static Texture2D LoadTextureFromFile(string FilePath)
+        {
+            if (File.Exists(FilePath))
+            {
+                return LoadTextureRaw(File.ReadAllBytes(FilePath));
+            }
+            return null;
+        }
+
+        public static Texture2D LoadTextureFromResources(string resourcePath)
+        {
+            return LoadTextureRaw(GetResource(Assembly.GetCallingAssembly(), resourcePath));
+        }
+
+        public static Sprite LoadSpriteRaw(byte[] image, float PixelsPerUnit = 100.0f)
+        {
+            return LoadSpriteFromTexture(LoadTextureRaw(image), PixelsPerUnit);
+        }
+
+        public static Sprite LoadSpriteFromTexture(Texture2D SpriteTexture, float PixelsPerUnit = 100.0f)
+        {
+            if (SpriteTexture)
+                return Sprite.Create(SpriteTexture, new Rect(0, 0, SpriteTexture.width, SpriteTexture.height), new Vector2(0, 0), PixelsPerUnit);
+
+            return null;
+        }
+
+        public static Sprite LoadSpriteFromFile(string FilePath, float PixelsPerUnit = 100.0f)
+        {
+            return LoadSpriteFromTexture(LoadTextureFromFile(FilePath), PixelsPerUnit);
+        }
+
+        public static Sprite LoadSpriteFromResources(string resourcePath, float PixelsPerUnit = 100.0f)
+        {
+            return LoadSpriteRaw(GetResource(Assembly.GetCallingAssembly(), resourcePath), PixelsPerUnit);
+        }
+
+        public static byte[] GetResource(Assembly asm, string ResourceName)
+        {
+            System.IO.Stream stream = asm.GetManifestResourceStream(ResourceName);
+            byte[] data = new byte[stream.Length];
+            stream.Read(data, 0, (int)stream.Length);
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
A more complete version of AssetReference for Appliances, Items and Processes
Example Usage: `var chopProcess = GDOUtils.GetExistingProcess(ProcessReference.Chop);`

These references will need updating/appending when the game updates with additional content. 