### PR TITLE
Refactor models

### DIFF
--- a/KitchenLib.TestMod/KitchenLib.TestMod.csproj
+++ b/KitchenLib.TestMod/KitchenLib.TestMod.csproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <Configurations>MelonLoader;BepInEx;Workshop</Configurations>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.5.6" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net472</TargetFramework>
+		<Configurations>MelonLoader;BepInEx;Workshop</Configurations>
+		<EnableModDeployLocal>false</EnableModDeployLocal>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\KitchenLib\KitchenLib.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.5.6" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\KitchenLib\KitchenLib.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/KitchenLib.TestMod/KitchenLib.TestMod.csproj
+++ b/KitchenLib.TestMod/KitchenLib.TestMod.csproj
@@ -3,57 +3,12 @@
     <TargetFramework>net472</TargetFramework>
     <Configurations>MelonLoader;BepInEx;Workshop</Configurations>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\KitchenLib\KitchenLib.csproj" />
+    <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.5.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\Libraries\MelonLoader\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\Libraries\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.Common">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.GameData">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.GameData.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.RestaurantMode">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.RestaurantMode.dll</HintPath>
-    </Reference>
-    <Reference Include="KitchenMods">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\KitchenMods.dll</HintPath>
-    </Reference>
-    <Reference Include="MelonLoader">
-      <HintPath>..\..\..\..\Libraries\MelonLoader\MelonLoader.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Entities">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Unity.Entities.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ClothModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.InputModule.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\KitchenLib\KitchenLib.csproj" />
   </ItemGroup>
 
 </Project>

--- a/KitchenLib.TestMod/Properties/AssemblyInfo.cs
+++ b/KitchenLib.TestMod/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-using MelonLoader;
-
-[assembly: MelonInfo(typeof(KitchenLib.TestMod.Main), "KitchenLib.TestMod", "0.1.0", "KitchenMods")]
-[assembly: MelonGame("It's Happening", "PlateUp")]

--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -1,124 +1,44 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <Configurations>MelonLoader;BepInEx;Workshop</Configurations>
-    <AssemblyName>$(MSBuildProjectName)-$(Configuration)</AssemblyName>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net472</TargetFramework>
+		<Configurations>MelonLoader;BepInEx;Workshop</Configurations>
+		<AssemblyName>$(MSBuildProjectName)-$(Configuration)</AssemblyName>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\.editorconfig" Link=".editorconfig" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\Libraries\MelonLoader\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\Libraries\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="Controllers">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Controllers.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.Common">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.FranchiseMode">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.FranchiseMode.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.GameData">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.GameData.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.Layouts">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.Layouts.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.Networking">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.Networking.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.Persistence">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.Persistence.dll</HintPath>
-    </Reference>
-    <Reference Include="Kitchen.RestaurantMode">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Kitchen.RestaurantMode.dll</HintPath>
-    </Reference>
-    <Reference Include="KitchenMode">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\KitchenMode.dll</HintPath>
-    </Reference>
-    <Reference Include="KitchenMods">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\KitchenMods.dll</HintPath>
-    </Reference>
-    <Reference Include="MelonLoader">
-      <HintPath>..\..\..\..\Libraries\MelonLoader\MelonLoader.dll</HintPath>
-    </Reference>
-    <Reference Include="MessagePack">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\MessagePack.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Sirenix.Serialization">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Sirenix.Serialization.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Memory">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\System.Memory.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Entities">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Unity.Entities.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Mathematics">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Unity.Mathematics.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Serialization">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Unity.Serialization.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="XNode">
-      <HintPath>..\..\..\..\Libraries\PlateUp_Data\Managed\XNode.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.5.6" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Properties\Settings.Designer.cs">
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-    </Compile>
-  </ItemGroup>
+	<ItemGroup>
+		<Reference Include="0Harmony">
+			<HintPath>..\..\..\..\Libraries\MelonLoader\0Harmony.dll</HintPath>
+		</Reference>
+		<Reference Include="BepInEx">
+			<HintPath>..\..\..\..\Libraries\BepInEx\core\BepInEx.dll</HintPath>
+		</Reference>
+		<Reference Include="MelonLoader">
+			<HintPath>..\..\..\..\Libraries\MelonLoader\MelonLoader.dll</HintPath>
+		</Reference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Update="Properties\Settings.Designer.cs">
+			<DesignTimeSharedInput>True</DesignTimeSharedInput>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>Settings.settings</DependentUpon>
+		</Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="Properties\Settings.settings">
+			<Generator>SettingsSingleFileGenerator</Generator>
+			<LastGenOutput>Settings.Designer.cs</LastGenOutput>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomAppliance.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomAppliance.cs
@@ -8,41 +8,41 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomAppliance : CustomLocalisedGameDataObject<ApplianceInfo>
     {
-        public virtual GameObject Prefab { get; internal set; }
-        public virtual GameObject HeldAppliancePrefab { get; internal set; }
-        public virtual List<Appliance.ApplianceProcesses> Processes { get { return new List<Appliance.ApplianceProcesses>(); } }
-        public virtual List<IApplianceProperty> Properties { get { return new List<IApplianceProperty>(); } }
-        public virtual IEffectRange EffectRange { get; internal set; }
-        public virtual IEffectCondition EffectCondition { get; internal set; }
-        public virtual IEffectType EffectType { get; internal set; }
-        public virtual EffectRepresentation EffectRepresentation { get; internal set; }
-        public virtual bool IsNonInteractive { get; internal set; }
-        public virtual OccupancyLayer Layer { get; internal set; }
-        public virtual bool ForceHighInteractionPriority { get; internal set; }
-        public virtual int PurchaseCost { get { return 0; } }
-        public virtual EntryAnimation EntryAnimation { get; internal set; }
-        public virtual ExitAnimation ExitAnimation { get; internal set; }
-        public virtual bool SkipRotationAnimation { get; internal set; }
-        public virtual bool IsPurchasable { get { return false; } }
-        public virtual bool IsPurchasableAsUpgrade { get; internal set; }
-        public virtual DecorationType ThemeRequired { get; internal set; }
-        public virtual ShoppingTags ShoppingTags { get { return ShoppingTags.None; } }
-        public virtual RarityTier RarityTier { get { return RarityTier.Common; } }
-        public virtual PriceTier PriceTier { get { return PriceTier.Medium; } }
-        public virtual ShopRequirementFilter ShopRequirementFilter { get; internal set; }
-        public virtual List<Appliance> RequiresForShop { get { return new List<Appliance>(); } }
-        public virtual List<Process> RequiresProcessForShop { get { return new List<Process>(); } }
-        public virtual bool StapleWhenMissing { get; internal set; }
-        public virtual bool SellOnlyAsDuplicate { get; internal set; }
-        public virtual bool PreventSale { get; internal set; }
-        public virtual List<Appliance> Upgrades { get { return new List<Appliance>(); } }
-        public virtual bool IsAnUpgrade { get; internal set; }
-        public virtual bool IsNonCrated { get; internal set; }
-        public virtual Item CrateItem { get; internal set; }
-        public virtual string Name { get { return "Appliance"; } }
-        public virtual string Description { get { return "A little something for your restaurant"; } }
-        public virtual List<Appliance.Section> Sections { get { return new List<Appliance.Section>(); } }
-        public virtual List<string> Tags { get { return new List<string>(); } }
+        public virtual GameObject Prefab { get; protected set; }
+        public virtual GameObject HeldAppliancePrefab { get; protected set; }
+        public virtual List<Appliance.ApplianceProcesses> Processes { get; protected set; } = new List<Appliance.ApplianceProcesses>();
+        public virtual List<IApplianceProperty> Properties { get; protected set; } = new List<IApplianceProperty>();
+        public virtual IEffectRange EffectRange { get; protected set; }
+        public virtual IEffectCondition EffectCondition { get; protected set; }
+        public virtual IEffectType EffectType { get; protected set; }
+        public virtual EffectRepresentation EffectRepresentation { get; protected set; }
+        public virtual bool IsNonInteractive { get; protected set; }
+        public virtual OccupancyLayer Layer { get; protected set; }
+        public virtual bool ForceHighInteractionPriority { get; protected set; }
+        public virtual int PurchaseCost { get; protected set; } = 0;
+        public virtual EntryAnimation EntryAnimation { get; protected set; }
+        public virtual ExitAnimation ExitAnimation { get; protected set; }
+        public virtual bool SkipRotationAnimation { get; protected set; }
+        public virtual bool IsPurchasable { get; protected set; } = false;
+        public virtual bool IsPurchasableAsUpgrade { get; protected set; }
+        public virtual DecorationType ThemeRequired { get; protected set; }
+        public virtual ShoppingTags ShoppingTags { get; protected set; } = ShoppingTags.None;
+        public virtual RarityTier RarityTier { get; protected set; } = RarityTier.Common;
+        public virtual PriceTier PriceTier { get; protected set; } = PriceTier.Medium;
+        public virtual ShopRequirementFilter ShopRequirementFilter { get; protected set; }
+        public virtual List<Appliance> RequiresForShop { get; protected set; } = new List<Appliance>();
+        public virtual List<Process> RequiresProcessForShop { get; protected set; } = new List<Process>();
+        public virtual bool StapleWhenMissing { get; protected set; }
+        public virtual bool SellOnlyAsDuplicate { get; protected set; }
+        public virtual bool PreventSale { get; protected set; }
+        public virtual List<Appliance> Upgrades { get; protected set; } = new List<Appliance>();
+        public virtual bool IsAnUpgrade { get; protected set; }
+        public virtual bool IsNonCrated { get; protected set; }
+        public virtual Item CrateItem { get; protected set; }
+        public virtual string Name { get; protected set; } = "Appliance";
+        public virtual string Description { get; protected set; } = "A little something for your restaurant";
+        public virtual List<Appliance.Section> Sections { get; protected set; } = new List<Appliance.Section>();
+        public virtual List<string> Tags { get; protected set; } = new List<string>();
 
         public virtual bool ForceIsRotationPossible() { return false; }
         public virtual bool IsRotationPossible(InteractionData data) { return true; }
@@ -59,9 +59,9 @@ namespace KitchenLib.Customs
             Appliance result = ScriptableObject.CreateInstance<Appliance>();
 
             if (BaseGameDataObjectID != -1)
-                result = UnityEngine.Object.Instantiate(gameData.Get<Appliance>().FirstOrDefault(a => a.ID == BaseGameDataObjectID));
+                result = Object.Instantiate(gameData.Get<Appliance>().FirstOrDefault(a => a.ID == BaseGameDataObjectID));
             else
-                result = UnityEngine.Object.Instantiate(gameData.Get<Appliance>().FirstOrDefault(a => a.ID == AssetReference.Counter));
+                result = Object.Instantiate(gameData.Get<Appliance>().FirstOrDefault(a => a.ID == AssetReference.Counter));
 
             if (empty.ID != ID) result.ID = ID;
             if (empty.Prefab != Prefab) result.Prefab = Prefab;

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomCompositeUnlockPack.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomCompositeUnlockPack.cs
@@ -1,4 +1,5 @@
 ﻿using KitchenData;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -7,7 +8,6 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomCompositeUnlockPack : CustomUnlockPack
     {
-
         public virtual List<UnlockPack> Packs { get { return new List<UnlockPack>(); } }
 
         private static readonly CompositeUnlockPack empty = ScriptableObject.CreateInstance<CompositeUnlockPack>();

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomCompositeUnlockPack.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomCompositeUnlockPack.cs
@@ -1,5 +1,4 @@
 ﻿using KitchenData;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -8,7 +7,7 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomCompositeUnlockPack : CustomUnlockPack
     {
-        public virtual List<UnlockPack> Packs { get { return new List<UnlockPack>(); } }
+        public virtual List<UnlockPack> Packs { get; protected set; } = new List<UnlockPack>();
 
         private static readonly CompositeUnlockPack empty = ScriptableObject.CreateInstance<CompositeUnlockPack>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomCrateSet.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomCrateSet.cs
@@ -7,7 +7,7 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomCrateSet : CustomGameDataObject
     {
-        public virtual List<Appliance> Options { get { return new List<Appliance>(); } }
+        public virtual List<Appliance> Options { get; protected set; } = new List<Appliance>();
 
         private static readonly CrateSet empty = ScriptableObject.CreateInstance<CrateSet>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomDecor.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomDecor.cs
@@ -6,10 +6,10 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomDecor : CustomGameDataObject
     {
-        public virtual Material Material { get; internal set; }
-        public virtual Appliance ApplicatorAppliance { get; internal set; }
-        public virtual LayoutMaterialType Type { get; internal set; }
-        public virtual bool IsAvailable { get { return true; } }
+        public virtual Material Material { get; protected set; }
+        public virtual Appliance ApplicatorAppliance { get; protected set; }
+        public virtual LayoutMaterialType Type { get; protected set; }
+        public virtual bool IsAvailable { get; protected set; } = true;
 
         private static readonly Decor empty = ScriptableObject.CreateInstance<Decor>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomDish.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomDish.cs
@@ -1,4 +1,5 @@
 using KitchenData;
+using KitchenData;
 using KitchenLib.Utils;
 using System;
 using System.Collections.Generic;
@@ -10,20 +11,19 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomDish : CustomUnlock
     {
-        public virtual DishType Type { get; internal set; }
-        public virtual string AchievementName { get; internal set; }
-        public virtual HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks { get { return new HashSet<Dish.IngredientUnlock>(); } }
-        public virtual List<string> StartingNameSet { get { return new List<string>(); } }
-        public virtual HashSet<Item> MinimumIngredients { get { return new HashSet<Item>(); } }
-        public virtual HashSet<Process> RequiredProcesses { get { return new HashSet<Process>(); } }
-        public virtual HashSet<Item> BlockProviders { get { return new HashSet<Item>(); } }
-        public virtual GameObject IconPrefab { get; internal set; }
-        public virtual GameObject DisplayPrefab { get; internal set; }
+        public virtual DishType Type { get; protected set; }
+        public virtual string AchievementName { get; protected set; }
+        public virtual HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks { get; protected set; } = new HashSet<Dish.IngredientUnlock>();
+        public virtual List<string> StartingNameSet { get; protected set; } = new List<string>();
+        public virtual HashSet<Item> MinimumIngredients { get; protected set; } = new HashSet<Item>();
+        public virtual HashSet<Process> RequiredProcesses { get; protected set; } = new HashSet<Process>();
+        public virtual HashSet<Item> BlockProviders { get; protected set; } = new HashSet<Item>();
+        public virtual GameObject IconPrefab { get; protected set; }
+        public virtual GameObject DisplayPrefab { get; protected set; }
+        public virtual List<Dish.MenuItem> ResultingMenuItems { get; protected set; } = new List<Dish.MenuItem>();
+        public virtual HashSet<Dish.IngredientUnlock> IngredientsUnlocks { get; protected set; } = new HashSet<Dish.IngredientUnlock>();
+        public virtual HashSet<Dish> PrerequisiteDishesEditor { get; protected set; } = new HashSet<Dish>();
 
-
-        public virtual List<Dish.MenuItem> ResultingMenuItems { get { return new List<Dish.MenuItem>(); } }
-        public virtual HashSet<Dish.IngredientUnlock> IngredientsUnlocks { get { return new HashSet<Dish.IngredientUnlock>(); } }
-        public virtual HashSet<Dish> PrerequisiteDishesEditor { get { return new HashSet<Dish>(); } }
         private static readonly Dish empty = ScriptableObject.CreateInstance<Dish>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
         {

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomEffect.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomEffect.cs
@@ -7,11 +7,11 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomEffect : CustomGameDataObject
     {
-        public virtual List<IEffectProperty> Properties { get { return new List<IEffectProperty>(); } }
-        public virtual IEffectRange EffectRange { get; internal set; }
-        public virtual IEffectCondition EffectCondition { get; internal set; }
-        public virtual IEffectType EffectType { get; internal set; }
-        public virtual EffectRepresentation EffectInformation { get; internal set; }
+        public virtual List<IEffectProperty> Properties { get; protected set; } = new List<IEffectProperty>();
+        public virtual IEffectRange EffectRange { get; protected set; }
+        public virtual IEffectCondition EffectCondition { get; protected set; }
+        public virtual IEffectType EffectType { get; protected set; }
+        public virtual EffectRepresentation EffectInformation { get; protected set; }
 
         private static readonly Effect empty = ScriptableObject.CreateInstance<Effect>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomEffectRepresentation.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomEffectRepresentation.cs
@@ -6,9 +6,9 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomEffectRepresentation : CustomLocalisedGameDataObject<EffectInfo>
     {
-		public virtual string Name { get; internal set; }
-		public virtual string Description { get; internal set; }
-		public virtual string Icon { get; internal set; }
+		public virtual string Name { get; protected set; }
+		public virtual string Description { get; protected set; }
+		public virtual string Icon { get; protected set; }
 
         private static readonly EffectRepresentation empty = ScriptableObject.CreateInstance<EffectRepresentation>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomGameDataObject.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomGameDataObject.cs
@@ -5,14 +5,16 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomGameDataObject
     {
-        public virtual int ID { get; internal set; }
-        public virtual string UniqueNameID { get; internal set; }
-        public virtual int BaseGameDataObjectID { get { return -1; } }
+        public virtual int ID { get; protected set; }
+        public virtual string UniqueNameID { get; protected set; }
+        public virtual int BaseGameDataObjectID { get; protected set; } = -1;
+
         public string ModName = "";
         public GameDataObject GameDataObject;
+
         public abstract void Convert(GameData gameData, out GameDataObject gameDataObject);
-        public virtual void OnRegister(GameDataObject gameDataObject) { }
         public virtual void AttachDependentProperties(GameDataObject gameDataObject) { }
+        public virtual void OnRegister(GameDataObject gameDataObject) { }
 
         public int GetHash()
         {

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomGameDataObject.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomGameDataObject.cs
@@ -5,7 +5,7 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomGameDataObject
     {
-        public virtual int ID { get; protected set; }
+        public virtual int ID { get; internal set; }
         public virtual string UniqueNameID { get; protected set; }
         public virtual int BaseGameDataObjectID { get; protected set; } = -1;
 

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomGameDifficultySettings.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomGameDifficultySettings.cs
@@ -6,14 +6,14 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomGameDifficultySettings : CustomGameDataObject
     {
-        public virtual bool IsActive { get { return false; } }
-        public virtual float CustomersPerHourBase { get { return 1f; } }
-        public virtual float CustomersPerHourIncreasePerDay { get { return 0.2f; } }
-        public virtual float CustomerSideChance { get { return 1f; } }
-        public virtual float QueuePatienceTime { get { return 100f; } }
-        public virtual float QueuePatienceBoost { get { return 10f; } }
-        public virtual float CustomerStarterChance { get { return 1f; } }
-        public virtual float GroupDessertChance { get { return 1f; } }
+        public virtual bool IsActive { get; protected set; } = false;
+        public virtual float CustomersPerHourBase { get; protected set; } = 1f;
+        public virtual float CustomersPerHourIncreasePerDay { get; protected set; } = 0.2f;
+        public virtual float CustomerSideChance { get; protected set; } = 1f;
+        public virtual float QueuePatienceTime { get; protected set; } = 100f;
+        public virtual float QueuePatienceBoost { get; protected set; } = 10f;
+        public virtual float CustomerStarterChance { get; protected set; } = 1f;
+        public virtual float GroupDessertChance { get; protected set; } = 1f;
 
         private static readonly GameDifficultySettings empty = ScriptableObject.CreateInstance<GameDifficultySettings>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomGardenProfile.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomGardenProfile.cs
@@ -7,8 +7,8 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomGardenProfile : CustomGameDataObject
     {
-        public virtual Appliance SpawnHolder { get; internal set; }
-        public virtual List<GardenProfile.SpawnProbability> Spawns { get { return new List<GardenProfile.SpawnProbability>(); } }
+        public virtual Appliance SpawnHolder { get; protected set; }
+        public virtual List<GardenProfile.SpawnProbability> Spawns { get; protected set; } = new List<GardenProfile.SpawnProbability>();
 
         private static readonly GardenProfile empty = ScriptableObject.CreateInstance<GardenProfile>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomItem.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomItem.cs
@@ -10,34 +10,34 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomItem : CustomGameDataObject
     {
-        public virtual GameObject Prefab { get; internal set; }
-
-        public virtual List<Item.ItemProcess> Processes { get { return new List<Item.ItemProcess>(); } }
-        public virtual List<IItemProperty> Properties { get { return new List<IItemProperty>(); } }
-        public virtual float ExtraTimeGranted { get; internal set; }
-        public virtual ItemValue ItemValue { get { return ItemValue.Small; } }
+        public virtual GameObject Prefab { get; protected set; }
+        public virtual List<Item.ItemProcess> Processes { get; protected set; }=new List<Item.ItemProcess>();
+        public virtual List<IItemProperty> Properties { get; protected set; } = new List<IItemProperty>();
+        public virtual float ExtraTimeGranted { get; protected set; }
+        public virtual ItemValue ItemValue { get; protected set; } = ItemValue.Small;
         public virtual int Reward { get { return 1; } }
-        public virtual Item DirtiesTo { get; internal set; }
-        public virtual List<Item> MayRequestExtraItems { get { return new List<Item>(); } }
-        public virtual int MaxOrderSharers { get; internal set; }
-        public virtual Item SplitSubItem { get; internal set; }
-        public virtual int SplitCount { get { return 0; } }
-        public virtual float SplitSpeed { get { return 1f; } }
-        public virtual List<Item> SplitDepletedItems { get { return new List<Item>(); } }
-        public virtual bool AllowSplitMerging { get; internal set; }
-        public virtual bool PreventExplicitSplit { get; internal set; }
-        public virtual bool SplitByComponents { get; internal set; }
-        public virtual Item SplitByComponentsHolder { get; internal set; }
-        public virtual bool SplitByCopying { get; internal set; }
-        public virtual Item RefuseSplitWith { get; internal set; }
-        public virtual Item DisposesTo { get; internal set; }
-        public virtual bool IsIndisposable { get; internal set; }
-        public virtual ItemCategory ItemCategory { get; internal set; }
-        public virtual ItemStorage ItemStorageFlags { get; internal set; }
-        public virtual Appliance DedicatedProvider { get; internal set; }
-        public virtual ToolAttachPoint HoldPose { get { return ToolAttachPoint.Generic; } }
-        public virtual bool IsMergeableSide { get; internal set; }
-        public virtual Item ExtendedDirtItem { get; internal set; }
+        public virtual Item DirtiesTo { get; protected set; }
+        public virtual List<Item> MayRequestExtraItems { get; protected set; } = new List<Item>();
+        public virtual int MaxOrderSharers { get; protected set; }
+        public virtual Item SplitSubItem { get; protected set; }
+        public virtual int SplitCount { get; protected set; } = 0;
+        public virtual float SplitSpeed { get; protected set; } = 1f;
+        public virtual List<Item> SplitDepletedItems { get; protected set; } = new List<Item>();
+        public virtual bool AllowSplitMerging { get; protected set; }
+        public virtual bool PreventExplicitSplit { get; protected set; }
+        public virtual bool SplitByComponents { get; protected set; }
+        public virtual Item SplitByComponentsHolder { get; protected set; }
+        public virtual bool SplitByCopying { get; protected set; }
+        public virtual Item RefuseSplitWith { get; protected set; }
+        public virtual Item DisposesTo { get; protected set; }
+        public virtual bool IsIndisposable { get; protected set; }
+        public virtual ItemCategory ItemCategory { get; protected set; }
+        public virtual ItemStorage ItemStorageFlags { get; protected set; }
+        public virtual Appliance DedicatedProvider { get; protected set; }
+        public virtual ToolAttachPoint HoldPose { get; protected set; } = ToolAttachPoint.Generic;
+        public virtual bool IsMergeableSide { get; protected set; }
+        public virtual Item ExtendedDirtItem { get; protected set; }
+
         private static readonly Item empty = ScriptableObject.CreateInstance<Item>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
         {

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomItemGroup.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomItemGroup.cs
@@ -10,10 +10,11 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomItemGroup : CustomItem
     {
-        public virtual List<ItemGroup.ItemSet> Sets { get { return new List<ItemGroup.ItemSet>(); } }
-        public virtual bool CanContainSide { get; internal set; }
-        public virtual bool ApplyProcessesToComponents { get; internal set; }
-        public virtual bool AutoCollapsing { get; internal set; }
+        public virtual List<ItemGroup.ItemSet> Sets { get; protected set; } = new List<ItemGroup.ItemSet>();
+        public virtual bool CanContainSide { get; protected set; }
+        public virtual bool ApplyProcessesToComponents { get; protected set; }
+        public virtual bool AutoCollapsing { get; protected set; }
+
         private static readonly ItemGroup empty = ScriptableObject.CreateInstance<ItemGroup>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
         {

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomLayoutProfile.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomLayoutProfile.cs
@@ -15,7 +15,7 @@ namespace KitchenLib.Customs
         public virtual GameDataObject Counter { get; protected set; }
         public virtual Appliance ExternalBin { get; protected set; }
         public virtual Appliance WallPiece { get; protected set; }
-        public virtual Appliance protectedWallPiece { get; protected set; }
+        public virtual Appliance InternalWallPiece { get; protected set; }
         public virtual Appliance StreetPiece { get; protected set; }
         public virtual LocalisationObject<BasicInfo> Info { get; protected set; }
         public virtual string Name { get; protected set; } = "New Layout";
@@ -48,7 +48,7 @@ namespace KitchenLib.Customs
             if (empty.Counter != Counter) result.Counter = Counter;
             if (empty.ExternalBin != ExternalBin) result.ExternalBin = ExternalBin;
             if (empty.WallPiece != WallPiece) result.WallPiece = WallPiece;
-            if (empty.protectedWallPiece != protectedWallPiece) result.protectedWallPiece = protectedWallPiece;
+            if (empty.InternalWallPiece != InternalWallPiece) result.InternalWallPiece = InternalWallPiece;
             if (empty.StreetPiece != StreetPiece) result.StreetPiece = StreetPiece;
         }
     }

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomLayoutProfile.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomLayoutProfile.cs
@@ -8,18 +8,18 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomLayoutProfile : CustomGameDataObject
     {
-        public virtual LayoutGraph Graph { get; internal set; }
-        public virtual int MaximumTables { get { return 3; } }
-        public virtual List<GameDataObject> RequiredAppliances { get { return new List<GameDataObject>(); } }
-        public virtual GameDataObject Table { get; internal set; }
-        public virtual GameDataObject Counter { get; internal set; }
-        public virtual Appliance ExternalBin { get; internal set; }
-        public virtual Appliance WallPiece { get; internal set; }
-        public virtual Appliance InternalWallPiece { get; internal set; }
-        public virtual Appliance StreetPiece { get; internal set; }
-        public virtual LocalisationObject<BasicInfo> Info { get; internal set; }
-        public virtual string Name { get { return "New Layout"; } }
-        public virtual string Description { get { return "A new layout type for your restaurants!"; } }
+        public virtual LayoutGraph Graph { get; protected set; }
+        public virtual int MaximumTables { get; protected set; } = 3;
+        public virtual List<GameDataObject> RequiredAppliances { get; protected set; } = new List<GameDataObject>();
+        public virtual GameDataObject Table { get; protected set; }
+        public virtual GameDataObject Counter { get; protected set; }
+        public virtual Appliance ExternalBin { get; protected set; }
+        public virtual Appliance WallPiece { get; protected set; }
+        public virtual Appliance protectedWallPiece { get; protected set; }
+        public virtual Appliance StreetPiece { get; protected set; }
+        public virtual LocalisationObject<BasicInfo> Info { get; protected set; }
+        public virtual string Name { get; protected set; } = "New Layout";
+        public virtual string Description { get; protected set; } = "A new layout type for your restaurants!";
 
         private static readonly LayoutProfile empty = ScriptableObject.CreateInstance<LayoutProfile>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
@@ -48,7 +48,7 @@ namespace KitchenLib.Customs
             if (empty.Counter != Counter) result.Counter = Counter;
             if (empty.ExternalBin != ExternalBin) result.ExternalBin = ExternalBin;
             if (empty.WallPiece != WallPiece) result.WallPiece = WallPiece;
-            if (empty.InternalWallPiece != InternalWallPiece) result.InternalWallPiece = InternalWallPiece;
+            if (empty.protectedWallPiece != protectedWallPiece) result.protectedWallPiece = protectedWallPiece;
             if (empty.StreetPiece != StreetPiece) result.StreetPiece = StreetPiece;
         }
     }

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomLevelUpgradeSet.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomLevelUpgradeSet.cs
@@ -7,7 +7,7 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomLevelUpgradeSet : CustomGameDataObject
     {
-        public virtual List<LevelUpgrade> Upgrades { get { return new List<LevelUpgrade>(); } }
+        public virtual List<LevelUpgrade> Upgrades { get; protected set; } = new List<LevelUpgrade>();
 
         private static readonly LevelUpgradeSet empty = ScriptableObject.CreateInstance<LevelUpgradeSet>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomLocalisedGameDataObject.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomLocalisedGameDataObject.cs
@@ -4,8 +4,6 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomLocalisedGameDataObject<T> : CustomGameDataObject where T : Localisation
     {
-
-        public virtual LocalisationObject<T> Info { get; internal set; }
-
+        public virtual LocalisationObject<T> Info { get; protected set; }
     }
 }

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomModularUnlockPack.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomModularUnlockPack.cs
@@ -8,10 +8,10 @@ namespace KitchenLib.Customs
     public abstract class CustomModularUnlockPack : CustomUnlockPack
     {
 
-        public virtual List<IUnlockSet> Sets { get { return new List<IUnlockSet>(); } }
-        public virtual List<IUnlockFilter> Filter { get { return new List<IUnlockFilter>(); } }
-        public virtual List<IUnlockSorter> Sorters { get { return new List<IUnlockSorter>(); } }
-        public virtual List<ConditionalOptions> ConditionalOptions { get { return new List<ConditionalOptions>(); } }
+        public virtual List<IUnlockSet> Sets { get; protected set; } = new List<IUnlockSet>();
+        public virtual List<IUnlockFilter> Filter { get; protected set; } = new List<IUnlockFilter>();
+        public virtual List<IUnlockSorter> Sorters { get; protected set; } = new List<IUnlockSorter>();
+        public virtual List<ConditionalOptions> ConditionalOptions { get; protected set; } = new List<ConditionalOptions>();
 
         private static readonly ModularUnlockPack empty = ScriptableObject.CreateInstance<ModularUnlockPack>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomPlayerCosmetic.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomPlayerCosmetic.cs
@@ -7,12 +7,12 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomPlayerCosmetic : CustomLocalisedGameDataObject<CosmeticInfo>
     {
-        public virtual CosmeticType CosmeticType { get; internal set; }
-        public virtual List<RestaurantSetting> CustomerSettings { get { return new List<RestaurantSetting>(); } }
-        public virtual bool DisableInGame { get; internal set; }
-        public virtual bool IsDefault { get; internal set; }
-        public virtual bool BlockHats { get; internal set; }
-        public virtual GameObject Visual { get; internal set; }
+        public virtual CosmeticType CosmeticType { get; protected set; }
+        public virtual List<RestaurantSetting> CustomerSettings { get; protected set; } = new List<RestaurantSetting>();
+        public virtual bool DisableInGame { get; protected set; }
+        public virtual bool IsDefault { get; protected set; }
+        public virtual bool BlockHats { get; protected set; }
+        public virtual GameObject Visual { get; protected set; }
 
         private static readonly PlayerCosmetic empty = ScriptableObject.CreateInstance<PlayerCosmetic>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomProcess.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomProcess.cs
@@ -6,12 +6,12 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomProcess : CustomGameDataObject
     {
-        public virtual GameDataObject BasicEnablingAppliance { get; internal set; }
-        public virtual int EnablingApplianceCount { get { return 1; } }
-        public virtual Process IsPseudoprocessFor { get; internal set; }
-        public virtual bool CanObfuscateProgress { get; internal set; }
-        public virtual string Icon { get { return "!"; } }
-        public virtual LocalisationObject<ProcessInfo> Info { get; internal set; }
+        public virtual GameDataObject BasicEnablingAppliance { get; protected set; }
+        public virtual int EnablingApplianceCount { get; protected set; } = 1;
+        public virtual Process IsPseudoprocessFor { get; protected set; }
+        public virtual bool CanObfuscateProgress { get; protected set; }
+        public virtual string Icon { get; protected set; } = "!";
+        public virtual LocalisationObject<ProcessInfo> Info { get; protected set; }
 
         private static readonly Process empty = ScriptableObject.CreateInstance<Process>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomRandomUpgradeSet.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomRandomUpgradeSet.cs
@@ -7,8 +7,8 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomRandomUpgradeSet : CustomGameDataObject
     {
-        public virtual UpgradeRewardTier Tier { get; internal set; }
-        public virtual List<IUpgrade> Rewards { get { return new List<IUpgrade>(); } }
+        public virtual UpgradeRewardTier Tier { get; protected set; }
+        public virtual List<IUpgrade> Rewards { get; protected set; } = new List<IUpgrade>();
 
         private static readonly RandomUpgradeSet empty = ScriptableObject.CreateInstance<RandomUpgradeSet>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomResearch.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomResearch.cs
@@ -7,10 +7,10 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomResearch : CustomLocalisedGameDataObject<ResearchLocalisation>
     {
-        public virtual int RequiredResearch { get; internal set; }
-        public virtual List<IUpgrade> Rewards { get { return new List<IUpgrade>(); } }
-        public virtual List<Research> EnablesResearchOf { get { return new List<Research>(); } }
-        public virtual List<Research> RequiresForResearch { get { return new List<Research>(); } }
+        public virtual int RequiredResearch { get; protected set; }
+        public virtual List<IUpgrade> Rewards { get; protected set; } = new List<IUpgrade>();
+        public virtual List<Research> EnablesResearchOf { get; protected set; } = new List<Research>();
+        public virtual List<Research> RequiresForResearch { get; protected set; } = new List<Research>();
 
         private static readonly Research empty = ScriptableObject.CreateInstance<Research>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomShop.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomShop.cs
@@ -7,11 +7,11 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomShop : CustomGameDataObject
     {
-        public virtual List<Appliance> Stock { get { return new List<Appliance>(); } }
-        public virtual List<Decor> Decors { get { return new List<Decor>(); } }
-        public virtual ShopType Type { get; internal set; }
-        public virtual int ItemsForSaleCount { get { return 3; } }
-        public virtual int WallpapersForSaleCount { get { return 6; } }
+        public virtual List<Appliance> Stock { get; protected set; } = new List<Appliance>();
+        public virtual List<Decor> Decors { get; protected set; } = new List<Decor>();
+        public virtual ShopType Type { get; protected set; }
+        public virtual int ItemsForSaleCount { get; protected set; } = 3;
+        public virtual int WallpapersForSaleCount { get; protected set; } = 6;
 
         private static readonly Shop empty = ScriptableObject.CreateInstance<Shop>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomThemeUnlock.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomThemeUnlock.cs
@@ -8,10 +8,11 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomThemeUnlock : CustomUnlock
     {
-        public virtual bool IsPrimary { get { return true; } }
-        public virtual DecorationType Type { get; internal set; }
-        public virtual ThemeUnlock ParentTheme1 { get; internal set; }
-        public virtual ThemeUnlock ParentTheme2 { get; internal set; }
+        public virtual bool IsPrimary { get; protected set; } = true;
+        public virtual DecorationType Type { get; protected set; }
+        public virtual ThemeUnlock ParentTheme1 { get; protected set; }
+        public virtual ThemeUnlock ParentTheme2 { get; protected set; }
+
         private static readonly ThemeUnlock empty = ScriptableObject.CreateInstance<ThemeUnlock>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
         {

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomUnlock.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomUnlock.cs
@@ -1,20 +1,19 @@
 using KitchenData;
-using System;
 using System.Collections.Generic;
 
 namespace KitchenLib.Customs
 {
     public abstract class CustomUnlock : CustomLocalisedGameDataObject<UnlockInfo>
     {
-        public virtual Unlock.RewardLevel ExpReward { get { return Unlock.RewardLevel.Medium; } }
-        public virtual bool IsUnlockable { get { return true; } }
-        public virtual UnlockGroup UnlockGroup { get; internal set; }
-        public virtual CardType CardType { get; internal set; }
-        public virtual int MinimumFranchiseTier { get { return 0; } }
-        public virtual bool IsSpecificFranchiseTier { get; internal set; }
-        public virtual DishCustomerChange CustomerMultiplier { get; internal set; }
-        public virtual float SelectionBias { get { return 0f; } }
-        public virtual List<Unlock> HardcodedRequirements { get; internal set; }
-        public virtual List<Unlock> HardcodedBlockers { get; internal set; }
+        public virtual Unlock.RewardLevel ExpReward { get; protected set; } = Unlock.RewardLevel.Medium;
+        public virtual bool IsUnlockable { get; protected set; } = true;
+        public virtual UnlockGroup UnlockGroup { get; protected set; }
+        public virtual CardType CardType { get; protected set; }
+        public virtual int MinimumFranchiseTier { get; protected set; } = 0;
+        public virtual bool IsSpecificFranchiseTier { get; protected set; }
+        public virtual DishCustomerChange CustomerMultiplier { get; protected set; }
+        public virtual float SelectionBias { get; protected set; } = 0f;
+        public virtual List<Unlock> HardcodedRequirements { get; protected set; }
+        public virtual List<Unlock> HardcodedBlockers { get; protected set; }
     }
 }

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomUnlockCard.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomUnlockCard.cs
@@ -9,7 +9,8 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomUnlockCard : CustomUnlock
     {
-        public virtual List<UnlockEffect> Effects { get { return new List<UnlockEffect>(); } }
+        public virtual List<UnlockEffect> Effects { get; protected set; } = new List<UnlockEffect>();
+
         private static readonly UnlockCard empty = ScriptableObject.CreateInstance<UnlockCard>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
         {

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomUnlockPack.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomUnlockPack.cs
@@ -1,6 +1,4 @@
 ﻿namespace KitchenLib.Customs
 {
-    public abstract class CustomUnlockPack : CustomGameDataObject
-    {
-    }
+    public abstract class CustomUnlockPack : CustomGameDataObject { }
 }

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomWorkshopRecipe.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomWorkshopRecipe.cs
@@ -8,9 +8,9 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomWorkshopRecipe : CustomGameDataObject
     {
-        public virtual List<IWorkshopIndividualCondition> Conditions { get { return new List<IWorkshopIndividualCondition>(); } }
-        public virtual List<IWorkshopGroupCondition> GroupConditions { get { return new List<IWorkshopGroupCondition>(); } }
-        public virtual IWorkshopProduct Output { get; internal set; }
+        public virtual List<IWorkshopIndividualCondition> Conditions { get; protected set; } = new List<IWorkshopIndividualCondition>();
+        public virtual List<IWorkshopGroupCondition> GroupConditions { get; protected set; } = new List<IWorkshopGroupCondition>();
+        public virtual IWorkshopProduct Output { get; protected set; }
 
         private static readonly WorkshopRecipe empty = ScriptableObject.CreateInstance<WorkshopRecipe>();
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)

--- a/KitchenLib/src/Customs/CustomProcessTypes/CustomApplianceProcess.cs
+++ b/KitchenLib/src/Customs/CustomProcessTypes/CustomApplianceProcess.cs
@@ -4,10 +4,10 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomApplianceProccess : CustomSubProcess
     {
-        public virtual Process Process { get; internal set; }
-        public virtual bool IsAutomatic { get; internal set; }
-        public virtual float Speed { get; internal set; }
-        public virtual ProcessValidity Validity { get; internal set; }
+        public virtual Process Process { get; protected set; }
+        public virtual bool IsAutomatic { get; protected set; }
+        public virtual float Speed { get; protected set; }
+        public virtual ProcessValidity Validity { get; protected set; }
 
         public virtual void Convert(out Appliance.ApplianceProcesses applianceProcess)
         {

--- a/KitchenLib/src/Customs/CustomProcessTypes/CustomItemProcess.cs
+++ b/KitchenLib/src/Customs/CustomProcessTypes/CustomItemProcess.cs
@@ -4,11 +4,11 @@ namespace KitchenLib.Customs
 {
     public abstract class CustomItemProcess : CustomSubProcess
     {
-        public virtual Process Process { get; internal set; }
-        public virtual Item Result { get; internal set; }
-        public virtual float Duration { get; internal set; }
-        public virtual bool IsBad { get; internal set; }
-        public virtual bool RequiresWrapper { get; internal set; }
+        public virtual Process Process { get; protected set; }
+        public virtual Item Result { get; protected set; }
+        public virtual float Duration { get; protected set; }
+        public virtual bool IsBad { get; protected set; }
+        public virtual bool RequiresWrapper { get; protected set; }
 
         public virtual void Convert(out Item.ItemProcess itemProcess)
         {

--- a/KitchenLib/src/Customs/CustomProcessTypes/CustomSubProcess.cs
+++ b/KitchenLib/src/Customs/CustomProcessTypes/CustomSubProcess.cs
@@ -1,4 +1,3 @@
-using KitchenData;
 using System.Collections.Generic;
 using System;
 
@@ -7,7 +6,7 @@ namespace KitchenLib.Customs
     public abstract class CustomSubProcess
     {
 
-        public virtual string UniqueName { get; internal set; }
+        public virtual string UniqueName { get; protected set; }
 
 		public static Dictionary<string, CustomSubProcess> SubProcesses = new Dictionary<string, CustomSubProcess>();
 		public static Dictionary<Type, CustomSubProcess> SubProcessesByType = new Dictionary<Type, CustomSubProcess>();

--- a/KitchenLib/src/UI/ModsMenu.cs
+++ b/KitchenLib/src/UI/ModsMenu.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using KitchenMods;
 using System;
 using System.Reflection;
-using Harmony;
-using System.Xml.Linq;
 
 namespace KitchenLib
 {

--- a/KitchenLib/src/UI/ModsPreferencesMenu.cs
+++ b/KitchenLib/src/UI/ModsPreferencesMenu.cs
@@ -6,9 +6,6 @@ using System;
 using System.Reflection;
 using KitchenLib.Event;
 using KitchenLib.Utils;
-using System.Runtime.CompilerServices;
-using Harmony;
-using System.Linq.Expressions;
 
 namespace KitchenLib
 {


### PR DESCRIPTION
Cleaned up KitchenLib.TestMod so it will build without errors.
KitchenLib is now using Yariazen.PlateUp.ModBuildUtilities for easier building.
Refactored every single property to be get protected set with auto properties when needed with the exception of ID, it continues to be internal set because it is the only property that KitchenLib needs internal access to.