### PR TITLE
Automatically assign a name to the GameObjects created by Custom GDOs

### DIFF
--- a/KitchenLib/src/Patches/RegisterCustomGDOs.cs
+++ b/KitchenLib/src/Patches/RegisterCustomGDOs.cs
@@ -20,7 +20,7 @@ namespace KitchenLib.Customs
 			{
 				GameDataObject gameDataObject;
 				gdo.Convert(__result, out gameDataObject);
-				gameDataObject.name = gdo.UniqueNameID;
+				gameDataObject.name = $"{gdo.ModName} - {gdo.UniqueNameID}";
 				gdo.GameDataObject = gameDataObject;
 				gameDataObjects.Add(gameDataObject);
 			}

--- a/KitchenLib/src/Patches/RegisterCustomGDOs.cs
+++ b/KitchenLib/src/Patches/RegisterCustomGDOs.cs
@@ -20,6 +20,7 @@ namespace KitchenLib.Customs
 			{
 				GameDataObject gameDataObject;
 				gdo.Convert(__result, out gameDataObject);
+				gameDataObject.name = gdo.UniqueNameID;
 				gdo.GameDataObject = gameDataObject;
 				gameDataObjects.Add(gameDataObject);
 			}


### PR DESCRIPTION
This change is intended to eliminated the following pattern:
```cs
public override void OnRegister(GameDataObject gdo) {
    gdo.name = "whatever";
}
```
This PR makes it so that custom GDOs automatically set `gdo.name` to `ModName - UniqueNameID` to clean up code and make debugging easier (e.g., Unity Explorer)