### PR TITLE
Move colorblind label support from Colorblind+ to KitchenLib

### DIFF
--- a/KitchenLib/src/Colorblind/ColorblindUtils.cs
+++ b/KitchenLib/src/Colorblind/ColorblindUtils.cs
@@ -1,0 +1,85 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using System.Reflection;
+using TMPro;
+using UnityEngine;
+
+namespace KitchenLib.Colorblind {
+
+    public static class ColorblindUtils {
+
+        private static FieldInfo itemGroupView_colourblindLabel;
+        private static FieldInfo itemGroupView_componentLabels;
+        private static GameObject existingColourBlindChild;
+
+        public static void Init(GameData gameData) {
+            buildReflectionCache();
+            getExistingColourBlindChildToCloneFromPie(gameData);
+        }
+
+        private static void buildReflectionCache() {
+            itemGroupView_colourblindLabel = ReflectionUtils.GetField<ItemGroupView>("ColourblindLabel");
+            itemGroupView_componentLabels = ReflectionUtils.GetField<ItemGroupView>("ComponentLabels");
+        }
+
+        private static void getExistingColourBlindChildToCloneFromPie(GameData gameData) {
+            Item pie = gameData.Get<Item>(ItemReferences.PieMeatCooked);
+            existingColourBlindChild = GameObjectUtils.GetChildObject(pie.Prefab, "Colour Blind");
+        }
+
+        public static void SetupColorBlindFeatureForItem(ItemLabelGroup itemLabelGroup) {
+            Item item = GameData.Main.Get<Item>(itemLabelGroup.itemId);
+            ItemGroupView itemGroupView = item.Prefab.GetComponent<ItemGroupView>();
+            itemGroupView_componentLabels.SetValue(itemGroupView, ColourBlindLabelCreatorUtil.createLabelGroup(itemLabelGroup));
+
+            if (doesColourBlindChildExist(item)) {
+                Debug.Log($"{itemLabelGroup.itemId} already has a Colour Blind child.");
+                return;
+            }
+
+            GameObject clonedColourBlind = cloneColourBlindObjectAndAddToItem(item);
+            setColourBlindLabelObjectOnItemGroupView(itemGroupView, clonedColourBlind);
+        }
+
+        public static void AddSingleItemLabels(ItemLabel[] itemLabels) {
+            foreach (ItemLabel itemLabel in itemLabels) {
+                if (!GameData.Main.TryGet<Item>(itemLabel.itemId, out Item item)) {
+                    Debug.Log($"Colorblind error: Unable to find item for id {itemLabel.itemId}");
+                    continue;
+                }
+
+                GameObject clonedColourBlind = cloneColourBlindObjectAndAddToItem(item);
+                TextMeshPro textMeshProObject = getTextMeshProFromClonedObject(clonedColourBlind);
+                textMeshProObject.text = itemLabel.label;
+            }
+        }
+
+        public static bool doesColourBlindChildExist(Item item) {
+            return GameObjectUtils.GetChildObject(item.Prefab, "Colour Blind") != null;
+        }
+
+        public static GameObject cloneColourBlindObjectAndAddToItem(Item item) {
+            GameObject clonedColourBlind = Object.Instantiate(existingColourBlindChild);
+            clonedColourBlind.name = "Colour Blind";
+            clonedColourBlind.transform.SetParent(item.Prefab.transform);
+            clonedColourBlind.transform.localPosition = new Vector3(0, 0, 0);
+            return clonedColourBlind;
+        }
+
+
+        public static void setColourBlindLabelObjectOnItemGroupView(ItemGroupView itemGroupView, GameObject clonedColourBlind) {
+            if (itemGroupView_colourblindLabel.GetValue(itemGroupView) == null) {
+                TextMeshPro textMeshProObject = getTextMeshProFromClonedObject(clonedColourBlind);
+                textMeshProObject.text = "";
+                itemGroupView_colourblindLabel.SetValue(itemGroupView, textMeshProObject);
+            }
+        }
+
+        public static TextMeshPro getTextMeshProFromClonedObject(GameObject clonedColourBlind) {
+            GameObject titleChild = GameObjectUtils.GetChildObject(clonedColourBlind, "Title");
+            return titleChild.GetComponent<TextMeshPro>();
+        }
+    }
+}

--- a/KitchenLib/src/Colorblind/ColourBlindLabelCreatorUtil.cs
+++ b/KitchenLib/src/Colorblind/ColourBlindLabelCreatorUtil.cs
@@ -1,0 +1,19 @@
+﻿using Kitchen;
+using KitchenData;
+using System.Collections;
+using System.Linq;
+
+namespace KitchenLib.Colorblind {
+
+    public class ColourBlindLabelCreatorUtil : ItemGroupView {
+
+        public static IEnumerable createLabelGroup(ItemLabelGroup itemLabels) {
+            return itemLabels.itemLabels.ToList()
+                .Select(createLabel).ToList();
+        }
+
+        private static ColourBlindLabel createLabel(ItemLabel label) {
+            return new ColourBlindLabel { Item = GameData.Main.Get<Item>(label.itemId), Text = label.label };
+        }
+    }
+}

--- a/KitchenLib/src/Colorblind/ItemLabel.cs
+++ b/KitchenLib/src/Colorblind/ItemLabel.cs
@@ -1,0 +1,8 @@
+﻿namespace KitchenLib.Colorblind {
+
+    public class ItemLabel {
+
+        public int itemId { get; set; }
+        public string label { get; set; }
+    }
+}

--- a/KitchenLib/src/Colorblind/ItemLabelGroup.cs
+++ b/KitchenLib/src/Colorblind/ItemLabelGroup.cs
@@ -1,0 +1,8 @@
+﻿namespace KitchenLib.Colorblind {
+
+    public class ItemLabelGroup {
+
+        public int itemId { get; set; }
+        public ItemLabel[] itemLabels { get; set; }
+    }
+}

--- a/KitchenLib/src/Patches/RegisterCustomGDOs.cs
+++ b/KitchenLib/src/Patches/RegisterCustomGDOs.cs
@@ -9,6 +9,7 @@ using KitchenLib.Systems;
 using UnityEngine;
 using Kitchen;
 using System.IO;
+using KitchenLib.Colorblind;
 
 namespace KitchenLib.Customs
 {
@@ -130,6 +131,7 @@ namespace KitchenLib.Customs
 			__result.Dispose();
 			__result.InitialiseViews();
 
+			ColorblindUtils.Init(__result);
 			EventUtils.InvokeEvent(nameof(Events.BuildGameDataEvent), Events.BuildGameDataEvent?.GetInvocationList(), null, new BuildGameDataEventArgs(__result));
 		}
 	}


### PR DESCRIPTION
This allows adding colorblind support in other mods.

There are two public methods that matter to other modders:
**ColorblindUtils.AddSingleItemLabels**, a method for adding labels to standalone `Item`s (like Onions, Chopped Onions, etc). An example of how to add labels for multiple single items, in this case setting the label to "ONION" for whole and chopped onions.
```
ColorblindUtils.AddSingleItemLabels(new ItemLabel[] {
    new ItemLabel { itemId = ItemReferences.Onion, label = "ONION" },
    new ItemLabel { itemId = ItemReferences.OnionChopped, label = "ONION" },
});
```

**ColorblindUtils.SetupColorBlindFeatureForItem**, a method for adding labels for each of the ingredients in an `ItemGroupView` (like plated burgers, unplated burgers, etc). An example of how to add labels to burgers that show "ONION", "CHEEZ", and "TOMAT" depending on which ingredients are in the group. (The dynamic string is built by the game.)
```
ColorblindUtils.SetupColorBlindFeatureForItem(new ItemLabelGroup {
    itemId = ItemReferences.BurgerPlated,
    itemLabels = new ItemLabel[] {
        new ItemLabel { itemId = ItemReferences.OnionChopped, label = "ONION"},
        new ItemLabel { itemId = ItemReferences.CheeseGrated, label = "CHEEZ"},
        new ItemLabel { itemId = ItemReferences.TomatoChopped, label = "TOMAT"},
    }
});
```