### PR TITLE
Reference GDOs by name, fix bug with MaterialsUI, additional logging for potential bugs

### DIFF
--- a/KitchenLib/src/Customs/CustomGDO.cs
+++ b/KitchenLib/src/Customs/CustomGDO.cs
@@ -8,7 +8,7 @@ namespace KitchenLib.Customs
 	{
 		public static Dictionary<int, CustomGameDataObject> GDOs = new Dictionary<int, CustomGameDataObject>();
 		public static Dictionary<Type, CustomGameDataObject> GDOsByType = new Dictionary<Type, CustomGameDataObject>();
-		public static Dictionary<string, CustomGameDataObject> GDOsByName = new Dictionary<string, CustomGameDataObject>();
+		public static Dictionary<KeyValuePair<string, string>, CustomGameDataObject> GDOsByGUID = new Dictionary<KeyValuePair<string, string>, CustomGameDataObject>();
 
 		public static T RegisterGameDataObject<T>(T gdo) where T : CustomGameDataObject
 		{
@@ -17,13 +17,13 @@ namespace KitchenLib.Customs
 
 			if (GDOs.ContainsKey(gdo.ID))
 			{
-				Debug.LogWarning($"[KitchenLib] Error while registering custom GDO of type {gdo.GetType().FullName} with ID={gdo.ID} and UniqueNameId=\"{gdo.UniqueNameID}\". Double-check to ensure that the UniqueNameID is actually unique.");
+				Debug.LogWarning($"[KitchenLib] Error while registering custom GDO of type {gdo.GetType().FullName} with ID={gdo.ID} and Name=\"{gdo.ModName}:{gdo.UniqueNameID}\". Double-check to ensure that the UniqueNameID is actually unique.");
 				return null;
 			}
 
 			GDOs.Add(gdo.ID, gdo);
 			GDOsByType.Add(gdo.GetType(), gdo);
-			GDOsByName.Add(gdo.UniqueNameID, gdo);
+			GDOsByGUID.Add(new KeyValuePair<string, string>(gdo.ModName, gdo.UniqueNameID), gdo);
 
 			return gdo;
 		}

--- a/KitchenLib/src/Customs/CustomGDO.cs
+++ b/KitchenLib/src/Customs/CustomGDO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace KitchenLib.Customs
 {
@@ -7,6 +8,7 @@ namespace KitchenLib.Customs
 	{
 		public static Dictionary<int, CustomGameDataObject> GDOs = new Dictionary<int, CustomGameDataObject>();
 		public static Dictionary<Type, CustomGameDataObject> GDOsByType = new Dictionary<Type, CustomGameDataObject>();
+		public static Dictionary<string, CustomGameDataObject> GDOsByName = new Dictionary<string, CustomGameDataObject>();
 
 		public static T RegisterGameDataObject<T>(T gdo) where T : CustomGameDataObject
 		{
@@ -15,14 +17,13 @@ namespace KitchenLib.Customs
 
 			if (GDOs.ContainsKey(gdo.ID))
 			{
+				Debug.LogWarning($"[KitchenLib] Error while registering custom GDO of type {gdo.GetType().FullName} with ID={gdo.ID} and UniqueNameId=\"{gdo.UniqueNameID}\". Double-check to ensure that the UniqueNameID is actually unique.");
 				return null;
 			}
 
-			if (GDOs.ContainsKey(gdo.ID))
-				return null;
-
 			GDOs.Add(gdo.ID, gdo);
 			GDOsByType.Add(gdo.GetType(), gdo);
+			GDOsByName.Add(gdo.UniqueNameID, gdo);
 
 			return gdo;
 		}

--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomItemGroup.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomItemGroup.cs
@@ -72,7 +72,24 @@ namespace KitchenLib.Customs
             FieldInfo sets = ReflectionUtils.GetField<ItemGroup>("Sets");
 
             if (processes.GetValue(empty) != Processes) processes.SetValue(result, Processes);
-            if (sets.GetValue(empty) != Sets) sets.SetValue(gameDataObject, Sets);
+            if (sets.GetValue(empty) != Sets)
+            {
+                // Check for potential errors
+                for (int setIndex = 0; setIndex < Sets.Count; setIndex++)
+                {
+                    ItemGroup.ItemSet set = Sets[setIndex];
+                    for (int itemIndex = 0; itemIndex < set.Items.Count; itemIndex++)
+                    {
+                        Item item = set.Items[itemIndex];
+                        if (item == null || item.ID == 0)
+                        {
+                            Debug.LogWarning($"[KitchenLib] Found null or zero-ID item in an ItemSet in class {GetType().FullName} (set index {setIndex}, item index {itemIndex}). This will likely cause the game to crash.");
+                        }
+                    }
+                }
+
+                sets.SetValue(gameDataObject, Sets);
+            }
         }
     }
 }

--- a/KitchenLib/src/UI/MaterialsUI.cs
+++ b/KitchenLib/src/UI/MaterialsUI.cs
@@ -234,7 +234,7 @@ namespace KitchenLib.UI
 					_Color0W = _Color0.w,
 					_Color0X = _Color0.x,
 					_Color0Y = _Color0.y,
-					_Color0Z = _Color0.x,
+					_Color0Z = _Color0.z,
 					_Highlight = _Highlight,
 					_OverlayBase64 = imgtob64(_Overlay),
 					_HasTextureOverlay = _HasTextureOverlay,
@@ -343,7 +343,7 @@ namespace KitchenLib.UI
 					_ColorW = _Color.w,
 					_ColorX = _Color.x,
 					_ColorY = _Color.y,
-					_ColorZ = _Color.x,
+					_ColorZ = _Color.z,
 				};
 				string json = JsonConvert.SerializeObject(mat, Formatting.Indented);
 				File.WriteAllText(Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "/" + name + ".json", json);

--- a/KitchenLib/src/Utils/GDOUtils.cs
+++ b/KitchenLib/src/Utils/GDOUtils.cs
@@ -28,6 +28,12 @@ namespace KitchenLib.Utils
 			return gdo;
 		}
 
+		public static CustomGameDataObject GetCustomGameDataObject(string name)
+		{
+			CustomGDO.GDOsByName.TryGetValue(name, out var result);
+			return result;
+		}
+
 		public static CustomGameDataObject GetCustomGameDataObject(int id)
 		{
 			CustomGDO.GDOs.TryGetValue(id, out var result);
@@ -43,6 +49,11 @@ namespace KitchenLib.Utils
 		public static T GetCastedGDO<T, C>() where T : GameDataObject where C : CustomGameDataObject
 		{
 			return (T)GetCustomGameDataObject<C>()?.GameDataObject;
+		}
+
+		public static T GetCastedGDO<T>(string name) where T : GameDataObject
+		{
+			return (T)GetCustomGameDataObject(name)?.GameDataObject;
 		}
 	}
 }

--- a/KitchenLib/src/Utils/GDOUtils.cs
+++ b/KitchenLib/src/Utils/GDOUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using KitchenData;
 using System;
+using System.Linq;
 using KitchenLib.Customs;
 
 namespace KitchenLib.Utils
@@ -28,10 +29,15 @@ namespace KitchenLib.Utils
 			return gdo;
 		}
 
-		public static CustomGameDataObject GetCustomGameDataObject(string name)
+		public static CustomGameDataObject GetCustomGameDataObject(string modName, string name)
 		{
-			CustomGDO.GDOsByName.TryGetValue(name, out var result);
+			CustomGDO.GDOsByGUID.TryGetValue(new KeyValuePair<string, string>(modName, name), out var result);
 			return result;
+		}
+
+		public static List<CustomGameDataObject> GetCustomGameDataObjectsFromMod(string modName)
+		{
+			return CustomGDO.GDOsByGUID.Where(entry => entry.Key.Key == modName).Select(entry => entry.Value).ToList();
 		}
 
 		public static CustomGameDataObject GetCustomGameDataObject(int id)
@@ -51,9 +57,9 @@ namespace KitchenLib.Utils
 			return (T)GetCustomGameDataObject<C>()?.GameDataObject;
 		}
 
-		public static T GetCastedGDO<T>(string name) where T : GameDataObject
+		public static T GetCastedGDO<T>(string modName, string name) where T : GameDataObject
 		{
-			return (T)GetCustomGameDataObject(name)?.GameDataObject;
+			return (T)GetCustomGameDataObject(modName, name)?.GameDataObject;
 		}
 	}
 }


### PR DESCRIPTION
This PR does a few things:

- Added the ability to reference custom GDOs by their `UniqueNameId`. The intended use case of this feature is to make using GDOs from other mods (e.g., IngredientLib) easier and standardized.
- Added the ability to get all custom GDOs from a specific mod.
- Fixed a bug with `MaterialsUI` which made exported materials have colors with their B color component set to whatever R is.
- Added logging for when you attempt to register a custom GDO with the same name (and, thus, same ID) as another custom GDO. This will help mod developers find these bugs a lot easier.
- Added logging for when you attempt to create an ItemGroup with at least one `null` item in an ItemSet, which causes the game to crash and is really annoying to debug.