### PR TITLE
Only build and register custom GDOs once (thus also only calling OnRegister once)

### DIFF
--- a/KitchenLib/src/Event/Events.cs
+++ b/KitchenLib/src/Event/Events.cs
@@ -7,6 +7,7 @@ namespace KitchenLib.Event
     public static class Events
     {
         public static EventHandler<BuildGameDataEventArgs> BuildGameDataEvent;
+        public static EventHandler<BuildGameDataEventArgs> RebuildGameDataEvent;
         public static EventHandler<PlayerViewEventArgs> PlayerViewEvent;
 
 		public static EventHandler<PerformInitialSetupEventArgs> PerformInitialSetupEvent;


### PR DESCRIPTION
The motivation for this PR is the fact that `GameData` is built multiple times, thus re-creating custom GDOs multiple times. For reference, `GameData` is built once after mods are loaded, then again every time you load into a hub (your own or someone elses) (at least 2 times).

This PR modifies the custom GDO registration process in the following breaking-change ways:

- Custom GDOs are now only built once, instead of 2+ times. When `GameData` is rebuilt, use references to the pre-built GDOs instead. This means that `Convert`, `OnRegister`, and `AttachDependentProperties` are all now only called once per GDO. `SetupForGame`, `Localise`, and `SetupFinal` for all current GDOs are idempotent, so these have been allowed to repeat.
- Custom Dish recipes and hub options are now only registered once. This was actually a bug before that this change inadvertently fixes.
- **`BuildGameDataEvent` is now only called once, the first time that `GameData` is built.** This is a breaking change, though I only expect it to affect a few people, if any. For those people, a new event has been introduced:
- `RebuildGameDataEvent` has been added, which is called every time `GameData` is rebuilt. For modders having to modify GameData every time it is built, this event can allow them to maintain that functionality. It is worth discussing whether we want to modify this so that it also runs the first time that `GameData` is built. Personally, I think it would be better for the current functionality to be maintained.