### PR TITLE
Change how BuildGameDataEvent is fired

### DIFF
--- a/KitchenLib/src/Event/BuildGameDataEventArgs.cs
+++ b/KitchenLib/src/Event/BuildGameDataEventArgs.cs
@@ -6,9 +6,11 @@ namespace KitchenLib.Event
     public class BuildGameDataEventArgs : EventArgs
     {
         public readonly GameData gamedata;
-        internal BuildGameDataEventArgs(GameData gamedata)
+        public readonly bool firstBuild;
+        internal BuildGameDataEventArgs(GameData gamedata, bool firstBuild)
         {
             this.gamedata = gamedata;
+            this.firstBuild = firstBuild;
         }
     }
 }

--- a/KitchenLib/src/Event/Events.cs
+++ b/KitchenLib/src/Event/Events.cs
@@ -1,13 +1,13 @@
 using System;
 using Kitchen;
-using KitchenLib.Event;
 
 namespace KitchenLib.Event
 {
     public static class Events
     {
+        public static EventHandler<BuildGameDataEventArgs> BuildGameDataPreSetupEvent;
         public static EventHandler<BuildGameDataEventArgs> BuildGameDataEvent;
-        public static EventHandler<BuildGameDataEventArgs> RebuildGameDataEvent;
+        public static EventHandler<BuildGameDataEventArgs> BuildGameDataPostViewInitEvent;
         public static EventHandler<PlayerViewEventArgs> PlayerViewEvent;
 
 		public static EventHandler<PerformInitialSetupEventArgs> PerformInitialSetupEvent;

--- a/KitchenLib/src/Patches/RegisterCustomGDOs.cs
+++ b/KitchenLib/src/Patches/RegisterCustomGDOs.cs
@@ -47,6 +47,8 @@ namespace KitchenLib.Customs
 				}
 			}
 
+			EventUtils.InvokeEvent(nameof(Events.BuildGameDataPreSetupEvent), Events.BuildGameDataPreSetupEvent?.GetInvocationList(), null, new BuildGameDataEventArgs(__result, FirstRun));
+
 			foreach (GameDataObject gameDataObject in GameDataObjects)
 			{
 				try
@@ -140,17 +142,12 @@ namespace KitchenLib.Customs
 			}
 			 */
 
+			EventUtils.InvokeEvent(nameof(Events.BuildGameDataEvent), Events.BuildGameDataEvent?.GetInvocationList(), null, new BuildGameDataEventArgs(__result, FirstRun));
+
 			__result.Dispose();
 			__result.InitialiseViews();
 
-			if (FirstRun) // only call BuildGameDataEvent once
-			{
-				EventUtils.InvokeEvent(nameof(Events.BuildGameDataEvent), Events.BuildGameDataEvent?.GetInvocationList(), null, new BuildGameDataEventArgs(__result));
-			}
-			else
-			{
-				EventUtils.InvokeEvent(nameof(Events.RebuildGameDataEvent), Events.RebuildGameDataEvent?.GetInvocationList(), null, new BuildGameDataEventArgs(__result));
-			}
+			EventUtils.InvokeEvent(nameof(Events.BuildGameDataPostViewInitEvent), Events.BuildGameDataPostViewInitEvent?.GetInvocationList(), null, new BuildGameDataEventArgs(__result, FirstRun));
 
 			if (FirstRun)
             {

--- a/KitchenLib/src/Utils/ListUtils.cs
+++ b/KitchenLib/src/Utils/ListUtils.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace KitchenLib.Utils
+{
+    public static class ListUtils
+    {
+        public static bool IsNullOrEmpty<T>(this IEnumerable<T> list)
+        {
+            return list == null || list.Count() == 0;
+        }
+    }
+}


### PR DESCRIPTION
This change makes BuildGameDataEvent work to add new processes to vanilla items while still providing a means of using the old behavior, if necessary.