### PR TITLE
Mod menu fixes

### DIFF
--- a/KitchenLib/src/UI/ModsMenu.cs
+++ b/KitchenLib/src/UI/ModsMenu.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using KitchenMods;
 using System;
 using System.Reflection;
+using System.Linq;
 
 namespace KitchenLib
 {
@@ -20,6 +21,20 @@ namespace KitchenLib
 			ModPage.UntestedMods,
 			ModPage.NonKitchenLibMods
 		};
+
+        private static readonly float columnWidth = 6f;
+        private static readonly int modsPerColumn = 25;
+        private static readonly Vector2 selectPosition = new Vector2(1, 4);
+        private static readonly Vector2 backButtonPosition = new Vector2(1, 3.5f);
+        private static readonly List<string> modsToFilterOut = new List<string> {
+            "Mono.Cecil.dll",
+            "Mono.Cecil.Mdb.dll",
+            "Mono.Cecil.Pdb.dll",
+            "Mono.Cecil.Rocks.dll",
+            "MonoMod.RuntimeDetour.dll",
+            "MonoMod.Utils.dll",
+            "UniverseLib.Mono.dll",
+        };
 
 		private static List<string> modPagesNames = new List<string>
 		{
@@ -53,36 +68,25 @@ namespace KitchenLib
 			Redraw(player_id, ModPage.LoadedMods, modAssemblies, untestedMods, loadedMods);
 		}
 
-
 		private void Redraw(int player_id, ModPage mod_page, Dictionary<Assembly, string> modAssemblies, Dictionary<Type, BaseMod> untestedMods, Dictionary<Type, BaseMod> loadedMods)
 		{
 			ModuleList.Clear();
-			AddSelect<ModPage>(PageSelector);
+			AddSelect<ModPage>(PageSelector).Position = selectPosition;
+			New<SpacerElement>(true);
+			AddButton(base.Localisation["MENU_BACK_SETTINGS"], delegate (int i) {
+				this.RequestPreviousMenu();
+			}, 0, 1f, 0.2f).Position = backButtonPosition;
+
 			if (mod_page == ModPage.LoadedMods)
 			{
-				AddLabel("Loaded Mods");
-
-				foreach (Type modType in loadedMods.Keys)
-				{
-					BaseMod mod = loadedMods[modType];
-					AddInfo(mod.ModName + "     v" + mod.ModVersion);
-				}
+				createModLabels(loadedMods.Values.Select(modToModNameAndVersion).ToList());
 			}
 			else if (mod_page == ModPage.UntestedMods)
 			{
-
-				AddLabel("Untested Mods");
-
-				foreach (Type modType in untestedMods.Keys)
-				{
-					BaseMod mod = untestedMods[modType];
-					AddInfo(mod.ModName + "     v" + mod.ModVersion);
-				}
+				createModLabels(untestedMods.Values.Select(modToModNameAndVersion).ToList());
 			}
 			else if (mod_page == ModPage.NonKitchenLibMods)
 			{
-
-				AddLabel("Non-KitchenLib Mods");
 #if MELONLOADER
             System.Collections.ObjectModel.ReadOnlyCollection<MelonLoader.MelonMod> mods = MelonLoader.MelonMod.RegisteredMelons;
 			foreach (MelonLoader.MelonMod mod in mods)
@@ -104,41 +108,31 @@ namespace KitchenLib
             }
 #endif
 #if WORKSHOP
-
-				List<Mod> mods = ModPreload.Mods;
-				foreach (Mod mod in mods)
-				{
-					if (mod.State == ModState.PostActivated)
-					{
-						foreach (AssemblyModPack pack in mod.GetPacks<AssemblyModPack>())
-						{
-							if (!modAssemblies.ContainsValue(pack.Name))
-							{
-								if (!pack.Name.Equals("Mono.Cecil.dll") &&
-									!pack.Name.Equals("Mono.Cecil.Mdb.dll") &&
-									!pack.Name.Equals("Mono.Cecil.Pdb.dll") &&
-									!pack.Name.Equals("Mono.Cecil.Rocks.dll") &&
-									!pack.Name.Equals("MonoMod.RuntimeDetour.dll") &&
-									!pack.Name.Equals("MonoMod.Utils.dll") &&
-									!pack.Name.Equals("UniverseLib.Mono.dll"))
-								{
-									AddInfo(pack.Name.Replace(".dll", ""));
-								}
-							}
-						}
-					}
-				}
+				List<string> nonKlMods = ModPreload.Mods
+					.Where(mod => mod.State == ModState.PostActivated)
+					.SelectMany(mod => mod.GetPacks<AssemblyModPack>())
+					.Where(pack => !modAssemblies.ContainsValue(pack.Name) && !modsToFilterOut.Contains(pack.Name))
+					.Select(pack => pack.Name.Replace(".dll", "")).ToList();
+				createModLabels(nonKlMods);
 #endif
 			}
-
-			New<SpacerElement>(true);
-			New<SpacerElement>(true);
-			AddButton(base.Localisation["MENU_BACK_SETTINGS"], delegate (int i)
-			{
-				this.RequestPreviousMenu();
-			}, 0, 1f, 0.2f);
 		}
 
+        private string modToModNameAndVersion(BaseMod mod) => $"{mod.ModName}     v{mod.ModVersion}";
+
+        private void createModLabels(List<string> modNames) {
+            int columns = modNames.Count / modsPerColumn;
+            int i = 0;
+
+            modNames.OrderBy(x => x).ToList().ForEach(modName => {
+                InfoBoxElement infoBoxElement = AddInfo(modName);
+                infoBoxElement.SetSize(columnWidth, 1f);
+                infoBoxElement.Position = new Vector2(
+                    Mathf.Floor(i / modsPerColumn) * columnWidth - (columns * columnWidth / 2),
+                    i % modsPerColumn * -0.25f + 3f);
+                i++;
+            });
+        }
     }
 
 	public enum ModPage

--- a/KitchenLib/src/Utils/KitchenVersion.cs
+++ b/KitchenLib/src/Utils/KitchenVersion.cs
@@ -8,9 +8,10 @@ namespace KitchenLib.Utils
         public int Major { get; private set; }
         public int Minor { get; private set; }
         public int Patch { get; private set; }
+        public string Hotfix { get; private set; }
         public string Hash { get; private set; }
 
-        private Regex pattern = new Regex(@"([0-9])\.([0-9])\.([0-9]) \(([^)]*)");
+        private Regex pattern = new Regex(@"([0-9])\.([0-9])\.([0-9])([a-z]*) \(([^)]*)");
 
         public KitchenVersion(string versionString)
         {
@@ -23,14 +24,17 @@ namespace KitchenLib.Utils
                 Major = 0;
                 Minor = 0;
                 Patch = 0;
+                Hotfix = "";
                 Hash = "XXXX";
                 Main.instance.Log("ERROR - KitchenVersion: Version string is not valid. Using default version.");
-            }else
+            }
+            else
             {
                 Major = int.Parse(match.Groups[1].Value);
                 Minor = int.Parse(match.Groups[2].Value);
                 Patch = int.Parse(match.Groups[3].Value);
-                Hash = match.Groups[4].Value;
+                Hotfix = match.Groups[4].Value;
+                Hash = match.Groups[5].Value;
             }
         }
     }


### PR DESCRIPTION
Just a couple minor QoL changes.

1) Updates the version regex to not break on the hotfix version. The version check itself has not been updated, but this seems better than every mod being marked as incompatible and spamming the log with errors when we get a weird hotfix letter.
2) Changes the mod list to fit a lot more mods on the screen (and sort by name). This looks janky and can certainly be improved, but my goal was just to make it useful again.

When there are more than 25 mods in a list, it will split into columns. I tested up to 3 columns (with a smaller mods/column count), which would give us up to 75 KL mods, which is some breathing room at least.
![image](https://user-images.githubusercontent.com/22607691/217998525-45ec9250-24a2-4387-bfa9-7d29bc4396cc.png)

Single column example:
![image](https://user-images.githubusercontent.com/22607691/217998578-de3e547c-9171-4746-9444-aa54063b3008.png)
