### PR TITLE
Add modded dishes to the main menu

### DIFF
--- a/KitchenLib/src/Patches/ModdedDishShowcasePatches.cs
+++ b/KitchenLib/src/Patches/ModdedDishShowcasePatches.cs
@@ -1,0 +1,78 @@
+﻿using HarmonyLib;
+using Kitchen;
+using KitchenData;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace KitchenLib.src.Patches {
+
+    [HarmonyPatch(typeof(MenuBackgroundItemScroller), "Update")]
+    public class MenuBackgroundItemScroller_Update_Patch {
+
+        private static readonly int REFRESH_COOLDOWN = 500;
+        private static readonly int INITIAL_REFRESH_COOLDOWN = 0;
+        private static readonly string BACKDROP_NAME = "Cube";
+
+        private static int refreshCooldownRemaining = INITIAL_REFRESH_COOLDOWN;
+        private static bool hasRebuiltItems = false;
+
+        public static void Prefix(ref bool ___IsCreated, ref List<Item> ___Items, MenuBackgroundItemScroller __instance) {
+            if (isMenuHidden(__instance)) {
+                return;
+            }
+
+            if (refreshCooldownRemaining-- <= 0) {
+                rebuildItemListWithModdedDishesIfNeeded(ref ___Items);
+                ___Items.ShuffleInPlace();
+                removeAllCurrentDishes(ref __instance);
+                setIsCreatedToFalseToTriggerRedrawWithFreshItems(ref ___IsCreated);
+                refreshCooldownRemaining = REFRESH_COOLDOWN;
+            }
+        }
+
+        private static bool isMenuHidden(MenuBackgroundItemScroller menu) => !menu.Backdrop.activeInHierarchy;
+
+        private static void rebuildItemListWithModdedDishesIfNeeded(ref List<Item> items) {
+            if (hasRebuiltItems) {
+                return;
+            }
+
+            items = GameData.Main.Get<Dish>()
+                .SelectMany(dish => dish.UnlocksMenuItems)
+                .Select(menuItem => menuItem.Item)
+                .ToList();
+
+            hasRebuiltItems = true;
+        }
+
+        private static void removeAllCurrentDishes(ref MenuBackgroundItemScroller menu) {
+            List<GameObject> children = new List<GameObject>();
+            foreach (Transform child in menu.transform) {
+                if (child.name != BACKDROP_NAME) {
+                    children.Add(child.gameObject);
+                }
+            }
+            children.ForEach(Object.Destroy);
+        }
+
+        private static void setIsCreatedToFalseToTriggerRedrawWithFreshItems(ref bool isCreated) => isCreated = false;
+    }
+
+    [HarmonyPatch(typeof(MenuBackgroundItemScroller), "CreateItem")]
+    public class MenuBackgroundItemScroller_CreateItem_Patch {
+
+        public static void Postfix(ref GameObject __result) {
+            changeRotationSoItemsAreNotTopDown(__result);
+            bringItemForwardSlightlyAfterRotationSoItDoesNotClipWithBackground(__result);
+        }
+
+        private static void changeRotationSoItemsAreNotTopDown(GameObject item) {
+            item.transform.localRotation = Quaternion.Euler(new Vector3(-35, 0, 0));
+        }
+
+        private static void bringItemForwardSlightlyAfterRotationSoItDoesNotClipWithBackground(GameObject item) {
+            item.transform.localPosition += new Vector3(0, 0, -1);
+        }
+    }
+}


### PR DESCRIPTION
This patches two methods in MenuBackgroundItemScroller, to showcase modded dishes on the main menu.

Update: Updates the list of items that it will pull from, so that it includes the modded dishes. Also, while the menu is visible, it will now refresh after a delay, so you'll see more of a variety.

CreateItem: To make the rotation of the items look nicer, since the current items are fully top-down, which made tall items like drinks look very weird.

![image](https://user-images.githubusercontent.com/22607691/224512085-a1dce4e9-909f-4a02-9c43-3814fc60c830.png)
