### PR TITLE
GrantNecessary Fixes and API

### DIFF
--- a/KitchenLib/src/Patches/GrantNecessaryAppliances_Patch.cs
+++ b/KitchenLib/src/Patches/GrantNecessaryAppliances_Patch.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using Kitchen;
+using KitchenLib.References;
+using KitchenLib.src.Systems;
+
+namespace KitchenLib.src.Patches
+{
+	[HarmonyPatch(typeof(GrantNecessaryAppliances), "TotalPlates")]
+	public class GrantNecessaryAppliances_Patch
+	{
+		static void Postfix(ref int __result)
+		{
+			if (!GrantNecessarySystem.GameRequiresItem(ItemReferences.Plate))
+				__result = 99;
+		}
+	}
+}

--- a/KitchenLib/src/Systems/GrantNecessarySystem.cs
+++ b/KitchenLib/src/Systems/GrantNecessarySystem.cs
@@ -1,0 +1,113 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Utils;
+using KitchenMods;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+namespace KitchenLib.src.Systems
+{
+	[UpdateAfter(typeof(GrantNecessaryAppliances))]
+	public class GrantNecessarySystem : NightSystem, IModSystem
+	{
+		private static EntityQuery Unlocks;
+		private EntityQuery CreateAppliances;
+		private EntityQuery Providers;
+		private EntityQuery Parcels;
+		protected override void Initialise()
+		{
+			Unlocks = GetEntityQuery(new QueryHelper().All(typeof(CProgressionUnlock)));
+			CreateAppliances = GetEntityQuery(new QueryHelper().All(typeof(CCreateAppliance)));
+			Providers = GetEntityQuery(new QueryHelper().All(typeof(CAppliance)).Any(typeof(CItemProvider)));
+			Parcels = GetEntityQuery(new QueryHelper().All(typeof(CLetterAppliance)));
+		}
+
+		protected override void OnUpdate()
+		{
+			if (!CreateAppliances.IsEmpty)
+				return;
+
+			using var providers = Providers.ToComponentDataArray<CAppliance>(Allocator.Temp);
+			using var letters = Parcels.ToComponentDataArray<CLetterAppliance>(Allocator.Temp);
+
+			Dictionary<int, int> ProvidersOfType = new();
+			foreach (var appliance in providers)
+			{
+				if (!ProvidersOfType.TryGetValue(appliance.ID, out int current))
+					ProvidersOfType[appliance.ID] = 0;
+				ProvidersOfType[appliance.ID]++;
+			}
+			foreach (var letter in letters)
+			{
+				if (!ProvidersOfType.TryGetValue(letter.ApplianceID, out int current))
+					ProvidersOfType[letter.ApplianceID] = 0;
+				ProvidersOfType[letter.ApplianceID]++;
+			}
+
+			Dictionary<int, int> CountedItems = new();
+			foreach (var pair in ProvidersOfType)
+			{
+				if (pair.Value <= 0 || !GameData.Main.TryGet<Appliance>(pair.Key, out var appliance, false) || !appliance.GetProperty<CItemProvider>(out var provider))
+					continue;
+
+				if (GDOUtils.AutomatedParcelItems.Contains(provider.DefaultProvidedItem))
+				{
+					if (!CountedItems.TryGetValue(provider.DefaultProvidedItem, out var itemCount))
+						CountedItems[provider.DefaultProvidedItem] = 0;
+					CountedItems[provider.DefaultProvidedItem] += provider.Maximum * pair.Value;
+				}
+			}
+
+			var maxSize = GetOrDefault<SKitchenParameters>().Parameters.MaximumGroupSize;
+			int offset = 0;
+			foreach (var pair in CountedItems)
+			{
+				if (!GameRequiresItem(pair.Key))
+					continue;
+
+				if (pair.Value < maxSize)
+				{
+					var postTiles = GetPostTiles(false);
+					var parcelTile = GetParcelTile(postTiles, ref offset);
+					if (GameData.Main.TryGet<Item>(pair.Key, out var item, false) && item.DedicatedProvider != null)
+					{
+						PostHelpers.CreateApplianceParcel(EntityManager, parcelTile, item.DedicatedProvider.ID);
+					}
+				}
+			}
+		}
+
+		private Vector3 GetParcelTile(List<Vector3> tiles, ref int offset)
+		{
+			Vector3 vector = Vector3.zero;
+			bool flag = false;
+			while (!flag && offset < tiles.Count)
+			{
+				int num = offset;
+				offset = num + 1;
+				vector = tiles[num];
+				flag |= GetOccupant(vector, OccupancyLayer.Default) == default(Entity) && !GetTile(vector).HasFeature;
+			}
+			return flag ? vector : GetFallbackTile();
+		}
+
+		public static bool GameRequiresItem(int itemID)
+		{
+			using var unlocks = Unlocks.ToComponentDataArray<CProgressionUnlock>(Allocator.Temp);
+
+			foreach (var unlock in unlocks)
+			{
+				if (unlock.Type != CardType.Default)
+					continue;
+
+				if (GameData.Main.TryGet<Dish>(unlock.ID, out var dish, false) && dish.MinimumIngredients.Any(item => item.ID == itemID))
+					return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/KitchenLib/src/Utils/GDOUtils.cs
+++ b/KitchenLib/src/Utils/GDOUtils.cs
@@ -67,6 +67,15 @@ namespace KitchenLib.Utils
 			return (T)GetCustomGameDataObject(modID, name)?.GameDataObject;
 		}
 
+		public static List<int> AutomatedParcelItems = new();
+		public static void AddAutomatedParcel(Item item)
+		{
+			if (item.DedicatedProvider == null)
+				return;
+			if (!AutomatedParcelItems.Contains(item.ID))
+				AutomatedParcelItems.Add(item.ID);
+		}
+
 
 		public static Dictionary<int, List<int>> BlacklistedDishSides = new Dictionary<int, List<int>>();
 		public static void BlacklistSide(Item item, int side)


### PR DESCRIPTION
Allows the user to add their own necessity (e.g. different types of cups that are in short supply) and also disabling plates if they are not needed in a run.