### PR TITLE
Fix for ObjectSplittableView Not Updating Correctly When SplitDepletedItem is Splittable 

### DIFF
--- a/KitchenLib/src/Patches/ItemExtensions_Patch.cs
+++ b/KitchenLib/src/Patches/ItemExtensions_Patch.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using Kitchen;
+using KitchenData;
+using Unity.Entities;
+using KitchenLib.Systems;
+
+namespace KitchenLib.Patches
+{
+	[HarmonyPatch(typeof(ItemExtensions), nameof(ItemExtensions.ChangeItemType))]
+	static class ItemExtensions_Patch
+	{
+		static void Postfix(Entity item, int new_type)
+		{
+			if (GameData.Main.TryGet<Item>(new_type, out var output, warn_if_fail: true) && output.IsSplittable)
+			{
+				EntityManager entityManager = SplittableDepletedDelaySystem.instance.EntityManager;
+
+				SplittableDepletedDelaySystem.CSplittableDepletedDelay delay =
+					new SplittableDepletedDelaySystem.CSplittableDepletedDelay
+					{
+						IsFirstFrame = true,
+						TimeRemaining = 0.1f,
+						SplitCount = output.SplitCount
+					};
+
+				entityManager.AddComponent<SplittableDepletedDelaySystem.CSplittableDepletedDelay>(item);
+				entityManager.SetComponentData(item, delay);
+			}
+		}
+	}
+}

--- a/KitchenLib/src/Systems/SplittableDepletedDelaySystem.cs
+++ b/KitchenLib/src/Systems/SplittableDepletedDelaySystem.cs
@@ -1,0 +1,65 @@
+﻿using Kitchen;
+using KitchenMods;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace KitchenLib.Systems
+{
+	internal class SplittableDepletedDelaySystem : GameSystemBase, IModSystem
+	{
+		internal struct CSplittableDepletedDelay : IComponentData, IModComponent
+		{
+			public bool IsFirstFrame;
+			public float TimeRemaining;
+			public int SplitCount;
+		}
+
+		EntityQuery Items;
+
+		internal static SplittableDepletedDelaySystem instance;
+
+		protected override void Initialise()
+		{
+			base.Initialise();
+			instance = this;
+			Items = GetEntityQuery(new QueryHelper()
+				.All(typeof(CSplittableItem), typeof(CSplittableDepletedDelay)));
+		}
+		protected override void OnUpdate()
+		{
+			NativeArray<Entity> items = Items.ToEntityArray(Allocator.Temp);
+			NativeArray<CSplittableItem> splits = Items.ToComponentDataArray<CSplittableItem>(Allocator.Temp);
+			NativeArray<CSplittableDepletedDelay> delays = Items.ToComponentDataArray<CSplittableDepletedDelay>(Allocator.Temp);
+
+			float dt = Time.DeltaTime;
+
+			for (int i = 0; i < items.Length; i++)
+			{
+				Entity item = items[i];
+				CSplittableItem split = splits[i];
+				CSplittableDepletedDelay delay = delays[i];
+
+				if (delay.TimeRemaining < 0f)
+				{
+					split.RemainingCount = delay.SplitCount;
+					Set(item, split);
+					EntityManager.RemoveComponent<CSplittableDepletedDelay>(item);
+					continue;
+				}
+
+				if (delay.IsFirstFrame)
+				{
+					delay.IsFirstFrame = false;
+					split.RemainingCount = delay.SplitCount + 1;
+					Set(item, split);
+				}
+				delay.TimeRemaining -= dt;
+				Set(item, delay);
+			}
+
+			items.Dispose();
+			splits.Dispose();
+			delays.Dispose();
+		}
+	}
+}


### PR DESCRIPTION
When splitting item and remaining count is 0, item is changed into the split depleted item.
In this instance, `CSplittableItem` is updated to reflect the new item `SplitCount` before the new prefab is loaded, and the old prefab's `ObjectSplittableView` consumes the view update.

Hence. when the new prefab is instantiated, the new prefab's `ObjectSplittableView` does not receive the update, resulting in the wrong remaining count being shown visually.

The fix provides a view update with 100ms delay after the change is initiated.