### PR TITLE
Small fixes

### DIFF
--- a/KitchenLib/src/Customs/CustomGameDataObjects/CustomItem.cs
+++ b/KitchenLib/src/Customs/CustomGameDataObjects/CustomItem.cs
@@ -88,13 +88,13 @@ namespace KitchenLib.Customs
             if (RewardOverride != -1)
                 ItemOverrides.AddRewardOverride(result.ID, RewardOverride);
 
+			if (SidePrefab == null)
+			{
+				SidePrefab = result.Prefab ?? Main.bundle.LoadAsset<GameObject>("Error_Side");
+			}
 			if (result.Prefab == null)
 			{
 				result.Prefab = Main.bundle.LoadAsset<GameObject>("Error_Item");
-			}
-			if (SidePrefab == null)
-			{
-				SidePrefab = Main.bundle.LoadAsset<GameObject>("Error_Side");
 			}
 
 			gameDataObject = result;

--- a/KitchenLib/src/Patches/RegisterCustomGDOsPatch.cs
+++ b/KitchenLib/src/Patches/RegisterCustomGDOsPatch.cs
@@ -103,10 +103,23 @@ namespace KitchenLib.Patches
 							foreach (RecipeLocalisation loc in __result.Get<RecipeLocalisation>())
 							{
 								if (!loc.Text.ContainsKey(dish))
-									if (customDish.Recipe.ContainsKey((Locale)Enum.Parse(typeof(Locale), PlayerPrefs.GetString(Pref.Localisation))))
-										loc.Text.Add(dish, customDish.Recipe[(Locale)Enum.Parse(typeof(Locale), PlayerPrefs.GetString(Pref.Localisation))]);
+								{
+									if (Enum.TryParse<Locale>(PlayerPrefs.GetString(Pref.Localisation), out Locale locale))
+									{
+										if (customDish.Recipe.ContainsKey(locale))
+										{
+											loc.Text.Add(dish, customDish.Recipe[locale]);
+										}
+										else
+										{
+											loc.Text.Add(dish, customDish.Recipe[Locale.English]);
+										}
+									}
 									else
-										loc.Text.Add(dish, customDish.Recipe[Locale.English]);
+									{
+										Main.LogError($"Invalid Locale: {PlayerPrefs.GetString(Pref.Localisation)} encountered when registering {customDish.UniqueNameID}");
+									}
+								}
 							}
 						}
 						if (customDish.IsAvailableAsLobbyOption)


### PR DESCRIPTION
New PR.

Someone encountered a bizarre error with their preference locality returning an empty string. While that error shouldn't occur again, we might as well as use safer parsing and added an error log to make debugging this particular issue easier.

Also changes the prefab checking to the following for backwards compatibility. There's code made redundant by this change but I'll correct that in a future pr.
```
if (SidePrefab == null)
    SidePrefab = result.Prefab ?? Main.bundle.LoadAsset<GameObject>("Error_Side");
if (result.Prefab == null)
    result.Prefab = Main.bundle.LoadAsset<GameObject>("Error_Item");
```