### PR TITLE
KitchenLogger

### DIFF
--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -5,11 +5,10 @@
 		<Configurations>Workshop</Configurations>
 		<AssemblyName>$(MSBuildProjectName)-Workshop</AssemblyName>
 		<LangVersion>latest</LangVersion>
+		<NoWarn>0612;0618;0672</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<WorkshopDir>$(ProjectDir)content</WorkshopDir>
-		
 		<EnableAssetBundleDeploy>true</EnableAssetBundleDeploy>
 		
 		<EnableDocumentation>true</EnableDocumentation>
@@ -61,11 +60,4 @@
 		<None Remove="plateup_mod_metadata.json" />
 		<None Remove="*.png" />
 	</ItemGroup>
-
-	<!-- Deploy builds to content/ folder -->
-	<Target Name="BundleWorkshop" AfterTargets="Build" Condition="$(EnableModDeployLocal) == 'true'">
-		<Copy SourceFiles="$(TargetDir)$(MSBuildProjectName)-Workshop.dll" DestinationFolder="$(WorkshopDir)" />
-		<Copy SourceFiles="$(TargetDir)$(MSBuildProjectName)-Workshop.xml" DestinationFolder="$(WorkshopDir)" />
-	</Target>
-
 </Project>

--- a/KitchenLib/Main.cs
+++ b/KitchenLib/Main.cs
@@ -88,7 +88,7 @@ namespace KitchenLib
 		/// <param name="mod">The mod instance.</param>
 		protected override void OnPostActivate(Mod mod)
 		{
-			Logger = GetLogger();
+			Logger = InitLogger();
 			manager = new PreferenceManager(MOD_ID);
 			cosmeticManager = new PreferenceManager(MOD_ID + ".cosmetics");
 			manager.RegisterPreference(new PreferenceBool("enableChangingMenu", true));

--- a/KitchenLib/src/BaseMod.cs
+++ b/KitchenLib/src/BaseMod.cs
@@ -277,7 +277,7 @@ namespace KitchenLib
 			DevUIController._uiList.Add(menu);
 		}
 
-		public KitchenLogger GetLogger()
+		public KitchenLogger InitLogger()
 		{
 			return new KitchenLogger(ModName);
 		}

--- a/KitchenLib/src/BaseMod.cs
+++ b/KitchenLib/src/BaseMod.cs
@@ -1,5 +1,6 @@
 using KitchenLib.Customs;
 using KitchenLib.DevUI;
+using KitchenLib.Logging;
 using KitchenLib.Patches;
 using KitchenLib.Registry;
 using KitchenLib.Utils;
@@ -274,6 +275,11 @@ namespace KitchenLib
 		{
 			T menu = new T();
 			DevUIController._uiList.Add(menu);
+		}
+
+		public KitchenLogger GetLogger()
+		{
+			return new KitchenLogger(ModName);
 		}
 	}
 }

--- a/KitchenLib/src/IMMS/IMMSGameCreatorPatch.cs
+++ b/KitchenLib/src/IMMS/IMMSGameCreatorPatch.cs
@@ -2,7 +2,7 @@
 using Kitchen;
 using KitchenLib.IMMS;
 
-namespace KitchenLib.src.IMMS
+namespace KitchenLib.IMMS
 {
 	[HarmonyPatch(typeof(GameCreator), "PerformInitialSetup")]
 	internal class IMMSGameCreatorPatch

--- a/KitchenLib/src/Logging/Exceptions/MissingAssetBundleException.cs
+++ b/KitchenLib/src/Logging/Exceptions/MissingAssetBundleException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace KitchenLib.Logging.Exceptions
+{
+	public class MissingAssetBundleException : Exception
+	{
+		public MissingAssetBundleException(string modid) : base(modid + "missing AssetBundle.") { }
+	}
+}

--- a/KitchenLib/src/Logging/KitchenLogger.cs
+++ b/KitchenLib/src/Logging/KitchenLogger.cs
@@ -63,5 +63,56 @@ namespace KitchenLib.Logging
 		{
 			Debug.LogAssertion($"[{MOD_NAME}] " + message);
 		}
+
+		public void LogError(string MOD_NAME, string message)
+		{
+			Debug.LogError($"[{MOD_NAME}] " + message);
+		}
+
+		public void LogError(string MOD_NAME, object message)
+		{
+			LogError(MOD_NAME, message.ToString());
+		}
+
+		public void LogWarning(string MOD_NAME, string message)
+		{
+			Debug.LogWarning($"[{MOD_NAME}] " + message);
+		}
+
+		public void LogWarning(string MOD_NAME, object message)
+		{
+			LogWarning(MOD_NAME, message.ToString());
+		}
+
+		public void LogInfo(string MOD_NAME, string message)
+		{
+			Debug.Log($"[{MOD_NAME}] " + message);
+		}
+
+		public void LogInfo(string MOD_NAME, object message)
+		{
+			LogInfo(MOD_NAME, message.ToString());
+		}
+
+		public void LogException(string MOD_NAME, Exception e)
+		{
+			e.Data["MOD_NAME"] = MOD_NAME;
+			Debug.LogException(e);
+		}
+
+		public void LogAssert(string MOD_NAME, bool condition)
+		{
+			Debug.Assert(condition, $"[{MOD_NAME}] Assertion failed");
+		}
+
+		public void LogAssert(string MOD_NAME, bool condition, string message)
+		{
+			Debug.Assert(condition, $"[{MOD_NAME}] " + message);
+		}
+
+		public void LogAssert(string MOD_NAME, string message)
+		{
+			Debug.LogAssertion($"[{MOD_NAME}] " + message);
+		}
 	}
 }

--- a/KitchenLib/src/Logging/KitchenLogger.cs
+++ b/KitchenLib/src/Logging/KitchenLogger.cs
@@ -1,0 +1,67 @@
+﻿#define UNITY_ASSERTIONS
+using System;
+using UnityEngine;
+
+namespace KitchenLib.Logging
+{
+	public class KitchenLogger
+	{
+		internal string MOD_NAME;
+
+		public KitchenLogger(string MOD_NAME)
+		{
+			this.MOD_NAME = MOD_NAME;
+		}
+
+		public void LogError(string message)
+		{
+			Debug.LogError($"[{MOD_NAME}] " + message);
+		}
+
+		public void LogError(object message)
+		{
+			LogError(message.ToString());
+		}
+
+		public void LogWarning(string message)
+		{
+			Debug.LogWarning($"[{MOD_NAME}] " + message);
+		}
+
+		public void LogWarning(object message)
+		{
+			LogWarning(message.ToString());
+		}
+
+		public void LogInfo(string message)
+		{
+			Debug.Log($"[{MOD_NAME}] " + message);
+		}
+
+		public void LogInfo(object message)
+		{
+			LogInfo(message.ToString());
+		}
+
+		public void LogException(Exception e)
+		{
+			e.Data["MOD_NAME"] = MOD_NAME;
+			Debug.LogException(e);
+		}
+
+		public void LogAssert(bool condition)
+		{
+			Debug.Assert(condition, $"[{MOD_NAME}] Assertion failed");
+		}
+
+		public void LogAssert(bool condition, string message)
+		{
+			Debug.Assert(condition, $"[{MOD_NAME}] " + message);
+		}
+
+		public void LogAssert(string message)
+		{
+			Debug.LogAssertion($"[{MOD_NAME}] " + message);
+		}
+	}
+}

--- a/KitchenLib/src/Patches/DebugLogPatch.cs
+++ b/KitchenLib/src/Patches/DebugLogPatch.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using HarmonyLib;
+using System.Reflection;
+using KitchenLib.Utils;
+using System.Linq;
 
 namespace KitchenLib.Patches
 {
@@ -35,7 +38,27 @@ namespace KitchenLib.Patches
 
 			public void LogException(Exception exception, UnityEngine.Object context)
 			{
-				logHandler.LogException(exception, context);
+				string MOD_NAME = "PlateUp!";
+				if (exception.Data.Contains("MOD_NAME"))
+				{
+					MOD_NAME = (string)exception.Data["MOD_NAME"];
+					string message = $"[{MOD_NAME}] " + GetInnerExceptions(exception) + Environment.NewLine;
+					string[] stackTrace = Environment.StackTrace.Split(
+						new string[] { "\r\n", "\r", "\n" },
+						StringSplitOptions.None
+					);
+					for (int i = 5; i < stackTrace.Length; i++)
+					{
+						message += stackTrace[i] + Environment.NewLine;
+					}
+					LogFormat(LogType.Exception, context, message);
+				}
+				else
+				{
+					FieldInfo MessageField = ReflectionUtils.GetField<Exception>("_message", BindingFlags.Instance | BindingFlags.NonPublic);
+					MessageField.SetValue(exception, $"[{MOD_NAME}] " + exception.Message);
+					this.logHandler.LogException(exception, context);
+				}
 			}
 
 			public void LogFormat(LogType logType, UnityEngine.Object context, string format, params object[] args)
@@ -45,36 +68,34 @@ namespace KitchenLib.Patches
 					return;
 				}
 
-				var typePrefix = "";
-				switch (logType)
+				string typePrefix = logType switch
 				{
-					case LogType.Error:
-						typePrefix = "ERROR";
-						break;
-					case LogType.Assert:
-						typePrefix = "ASSERT";
-						break;
-					case LogType.Warning:
-						typePrefix = "WARN";
-						break;
-					case LogType.Log:
-						typePrefix = "INFO";
-						break;
-					case LogType.Exception:
-						typePrefix = "EXCEPTION";
-						break;
-				}
+					LogType.Error => "[ERROR] ",
+					LogType.Assert => "[ASSERT] ",
+					LogType.Warning => "[WARN] ",
+					LogType.Log => "[INFO] ",
+					LogType.Exception => "[EXCEPTION] ",
+				};
 
-				var modIdPrefix = "";
+				string modIdPrefix = "";
 				if (!Regex.IsMatch(string.Format(format, args), "^\\*?\\[.+\\]"))
 				{
 					modIdPrefix = "[PlateUp!] ";
 				}
-				
 
-				var newFormat = $"[{typePrefix}] " + modIdPrefix + format;
+
+				string newFormat = typePrefix + modIdPrefix + format;
 
 				logHandler.LogFormat(logType, context, newFormat, args);
+			}
+
+			private string GetInnerExceptions(Exception e)
+			{
+				if (e.InnerException == null)
+				{
+					return e.Message;
+				}
+				return e.Message + Environment.NewLine + GetInnerExceptions(e.InnerException);
 			}
 		}
 	}
@@ -84,7 +105,18 @@ namespace KitchenLib.Patches
 	{
 		public static bool Prefix(ref string msg)
 		{
-			msg = msg.Replace(Environment.UserName, "[USERNAME]");
+			string[] split = Regex.Matches(msg, @"\W+|[\w]+")
+				.Cast<Match>()
+				.Select(_ => _.Value)
+				.ToArray();
+			for (int i = 0; i < split.Length; i++)
+			{
+				if (split[i] == Environment.UserName)
+				{
+					split[i] = "[USERNAME]";
+				}
+			}
+			msg = string.Join("", split);
 			return true;
 		}
 	}

--- a/KitchenLib/src/Systems/LogSaveDetails.cs
+++ b/KitchenLib/src/Systems/LogSaveDetails.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using Unity.Entities;
 using UnityEngine;
 
-namespace KitchenLib.src.Systems
+namespace KitchenLib.Systems
 {
 	[UpdateAfter(typeof(EndSimulationEntityCommandBufferSystem))]
 	[UpdateBefore(typeof(PerformSaveRequests))]

--- a/KitchenLib/src/UI/PlateUp/ModSyncMenu.cs
+++ b/KitchenLib/src/UI/PlateUp/ModSyncMenu.cs
@@ -1,15 +1,13 @@
 ﻿using Kitchen.Modules;
 using Kitchen;
 using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 using KitchenLib.Views;
 using KitchenMods;
 using Steamworks.Data;
 using System.Threading.Tasks;
-using UnityEngine.SceneManagement;
 
-namespace KitchenLib.src.UI.PlateUp
+namespace KitchenLib.UI.PlateUp
 {
 	internal class ModSyncMenu : KLMenu<PauseMenuAction>
 	{

--- a/KitchenLib/src/UI/PlateUp/PreferenceMenu.cs
+++ b/KitchenLib/src/UI/PlateUp/PreferenceMenu.cs
@@ -1,18 +1,12 @@
 ﻿using Kitchen;
 using Kitchen.Modules;
-using KitchenLib.Customs;
 using KitchenLib.Preferences;
-using KitchenLib.Utils;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using UnityEngine;
-using Steamworks.Data;
-using KitchenMods;
 using KitchenLib.Views;
-using KitchenLib.src.UI.PlateUp;
-using KitchenLib.Systems;
+using KitchenLib.UI.PlateUp;
 
 namespace KitchenLib.UI
 {


### PR DESCRIPTION
Changes
- KitchenLogger: A complete wrapper of the Unity logger.
- BaseMod.InitLogger has been added to create a unified way of initializing the KitchenLogger.
- MissingAssetBundleException added as a safety check in Main.OnPostActivate. Will expand the exceptions going forward. We should throw exceptions when an unrecoverable error is encountered.
- KLLogHandler.LogException has been modified to provide more verbose logs for exceptions caught within mods. In other cases, the ModName of the mod that caused the exception is prepended to the message.
- KLLogHandler.LogFormat was cleaned up a bit because the modified LogException uses LogFormat for the mods case.
- DebugLogHandler_Patch.Prefix now uses regex matching to more likely find and replace the Username.
- Various namespace changes to remove the src from namespaces
- Main now has complete xml documentation
- Removed redundant properties in KitchenLib.csproj