### PR TITLE
Patch out CreateInstance error

### DIFF
--- a/KitchenLib/src/Patches/DebugLogPatch.cs
+++ b/KitchenLib/src/Patches/DebugLogPatch.cs
@@ -105,6 +105,11 @@ namespace KitchenLib.Patches
 	{
 		public static bool Prefix(ref string msg)
 		{
+			if (msg.Contains("must be instantiated using the ScriptableObject.CreateInstance method instead of"))
+			{
+				msg = "";
+				return true;
+			}
 			string[] split = Regex.Matches(msg, @"\W+|[\w]+")
 				.Cast<Match>()
 				.Select(_ => _.Value)


### PR DESCRIPTION
Patches out the "must be instantiated using the ScriptableObject.CreateInstance method instead of" error in the log.