### PR TITLE
CI Workflow for KitchenLib

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -115,6 +115,7 @@ jobs:
         echo "Uploading to steam workshop: ${{ inputs.itemid }}"
 
     - name: Upload to steam workshop
+      if: ${{ inputs.itemid != ''}}
       uses: weilbyte/steam-workshop-upload@952afac2862024c6adc8e242ecbcf77576c7665c
       with: 
         appid: 1599600 # Game's Steam App ID (PlateUp)

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -3,13 +3,8 @@ name: Build KitchenLib
 on:
   workflow_dispatch:
     inputs:
-      workshop_upload:
-        default: false
-        type: boolean
-        description: "Set to true if you wish to upload the built artifacts to the steam workshop"
-        required: false
-      appid:
-        description: 'The steam workshop app id to publish artifacts for'
+      itemid:
+        description: 'The steam workshop item id to publish artifacts for'
         required: false
         default: ''
         type: choice
@@ -21,8 +16,6 @@ on:
 jobs:
 
   build-and-sign:
-    env:
-      APP_ID: ${{ inputs.appid }} 
 
     strategy:
       matrix:
@@ -116,7 +109,18 @@ jobs:
         path: KitchenLib/content/
         if-no-files-found: error
 
-    - name: Upload to steam workshop
-      if: ${{ inputs.workshop_upload}}
+    - name: Steam workshop info
+      if: ${{ inputs.itemid != ''}}
       run: |
-        echo "Uploading to steam workshop: ${{ inputs.appid }}"
+        echo "Uploading to steam workshop: ${{ inputs.itemid }}"
+
+    - name: Upload to steam workshop
+      uses: weilbyte/steam-workshop-upload@952afac2862024c6adc8e242ecbcf77576c7665c
+      with: 
+        appid: 1599600 # Game's Steam App ID (PlateUp)
+        itemid: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
+        path: 'KitchenLib/content' # Path to your mod's folder from repository root
+      env:
+        STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }} # Your Steam username
+        STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }} # Your Steam password
+        STEAM_TFASEED: ${{ secrets.STEAM_SHARED_SECRET }} # Your Steam Guard 2FA shared secret (Optional)

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -9,7 +9,9 @@ on:
         default: ''
         type: choice
         options:
-          - '2999830291'
+          - '2898069883' # KitchenLib mod id
+          - '2932799348' # KitchenLib Beta mod id
+          - '2999830291' # Testing KitchenLib mod id
   push:
     branches: [ "development", "master" ]
 

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -1,12 +1,28 @@
-name: Build KitchenLib for Workshop
+name: Build KitchenLib
 
 on:
+  workflow_dispatch:
+    inputs:
+      workshop_upload:
+        default: false
+        type: boolean
+        description: "Set to true if you wish to upload the built artifacts to the steam workshop"
+        required: false
+      appid:
+        description: 'The steam workshop app id to publish artifacts for'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - '2999830291'
   push:
-    branches: [ "development" ]
+    branches: [ "development", "master" ]
 
 jobs:
 
   build-and-sign:
+    env:
+      APP_ID: ${{ inputs.appid }} 
 
     strategy:
       matrix:
@@ -36,11 +52,27 @@ jobs:
       uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
       with:
         shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
+
+    - name: Restore Cache
+      id: cache-things-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: depots
+        key: plateup-cache
+        restore-keys: |
+          plateup-cache
         
     - name: Download PlateUp Files
       run: |
           ./DepotDownloader -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }} <<< "${{ steps.generate.outputs.code }}"
-         
+    
+    - name: Save Cache
+      id: cache-things-save
+      uses: actions/cache/save@v3
+      with:
+        path: depots
+        key: plateup-cache-${{ hashFiles('depots/**/*.dll') }}
+
      # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
@@ -48,28 +80,18 @@ jobs:
         dotnet-version: |
          6.x
          
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    #- name: Setup MSBuild.exe
-    #  uses: microsoft/setup-msbuild@v1.0.2
-      
-    # Execute all unit tests in the solution
+    # Execute all unit tests in the solution TODO: Implement tests?
     #- name: Execute unit tests
     #  run: dotnet test
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    # - name: Build the application
-    #   run: |
-    #     $id = ls -Directory -Name $PWD/depots/1599601/
-    #     ls $PWD/depots/1599601/$id/PlateUp
-    #     msbuild $env:Solution_Name -r /p:Configuration=$env:Configuration /p:EnableModDeployLocal='true' /p:GamePath=$PWD/depots/1599601/$id/PlateUp
-    #   env:
-    #     Configuration: ${{ matrix.configuration }}
-
     - name: Build the application
       run: |
+        set -x
         dotnet --list-sdks
         ls -d $PWD/depots/1599601/**
-        dotnet build -c $Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='true'
+        dotnet build -c $Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='false' -p:EnableGameDebugging='false' --os windows --no-self-contained ./KitchenLib/KitchenLib.csproj
+        cp ./KitchenLib/bin/$Configuration/net472/windows-x64/KitchenLib-$Configuration.dll ./KitchenLib/content/
+        cp ./KitchenLib/bin/$Configuration/net472/KitchenLib-$Configuration.xml ./KitchenLib/content/
       env:
         Configuration: ${{ matrix.configuration }}
 
@@ -81,9 +103,10 @@ jobs:
       run: |
         cosign sign-blob --yes ./KitchenLib/content/KitchenLib-Workshop.dll --bundle ./KitchenLib/content/cosign.bundle
 
-
-    - name: Print Directory Contents
-      run: ls ./KitchenLib/content/
+    - name: Perform Hashes
+      run: |
+        sha256sum ./KitchenLib/content/* > ./KitchenLib/content/checksums.txt
+        ls ./KitchenLib/content/
 
     # Upload the build artifacts for later use
     - name: Upload build artifacts
@@ -92,3 +115,8 @@ jobs:
         name: Workshop Build
         path: KitchenLib/content/
         if-no-files-found: error
+
+    - name: Upload to steam workshop
+      if: ${{ inputs.workshop_upload}}
+      run: |
+        echo "Uploading to steam workshop: ${{ inputs.appid }}"

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -109,19 +109,25 @@ jobs:
         path: KitchenLib/content/
         if-no-files-found: error
 
-    - name: Steam workshop info
+    - name: Setup steamcmd
       if: ${{ inputs.itemid != ''}}
-      run: |
-        echo "Uploading to steam workshop: ${{ inputs.itemid }}"
+      uses: CyberAndrii/setup-steamcmd@b786e0da44db3d817e66fa3910a9560cb28c9323
+
+    - name: Generate auth code
+      if: ${{ inputs.itemid != ''}}
+      id: generate-code
+      uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
+      with:
+        shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
 
     - name: Upload to steam workshop
       if: ${{ inputs.itemid != ''}}
-      uses: weilbyte/steam-workshop-upload@952afac2862024c6adc8e242ecbcf77576c7665c
-      with: 
-        appid: 1599600 # Game's Steam App ID (PlateUp)
-        itemid: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
-        path: 'KitchenLib/content' # Path to your mod's folder from repository root
+      run: |
+        ./upload.sh
       env:
-        STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }} # Your Steam username
-        STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }} # Your Steam password
-        STEAM_TFASEED: ${{ secrets.STEAM_SHARED_SECRET }} # Your Steam Guard 2FA shared secret (Optional)
+        INPUT_APPID: 1599600 # Game's Steam App ID (PlateUp)
+        INPUT_ITEMID: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
+        INPUT_PATH: 'KitchenLib/content' # Path to your mod's folder from repository root
+        STEAM_USERNAME: '${{ secrets.STEAM_USERNAME }}' # Your Steam username
+        STEAM_PASSWORD: '${{ secrets.STEAM_PASSWORD }}' # Your Steam password
+        STEAM_CODE: ${{ steps.generate-code.outputs.code }}

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,0 +1,97 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
+# built on .NET Core.
+# To learn how to migrate your existing application to .NET Core,
+# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
+#
+# To configure this workflow:
+#
+# 1. Configure environment variables
+# GitHub sets default environment variables for every workflow run.
+# Replace the variables relative to your project in the "env" section below.
+#
+# 2. Signing
+# Generate a signing certificate in the Windows Application
+# Packaging Project or add an existing signing certificate to the project.
+# Next, use PowerShell to encode the .pfx file using Base64 encoding
+# by running the following Powershell script to generate the output string:
+#
+# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
+# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
+#
+# Open the output file, SigningCertificate_Encoded.txt, and copy the
+# string inside. Then, add the string to the repo as a GitHub secret
+# and name it "Base64_Encoded_Pfx."
+# For more information on how to configure your signing certificate for
+# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
+#
+# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
+# See "Build the Windows Application Packaging project" below to see how the secret is used.
+#
+# For more information on GitHub Actions, refer to https://github.com/features/actions
+# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
+# refer to https://github.com/microsoft/github-actions-for-desktop-apps
+
+name: .NET Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Release]
+
+    runs-on: windows-latest  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    env:
+      Solution_Name: KitchenLib.sln                        # Replace with your solution name, i.e. MyWpfApp.sln.
+      Test_Project_Path: KitchenLib.TestMod\KitchenLib.TestMod.csproj                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
+      #Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
+      #Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    # Install the .NET Core workload
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    # Execute all unit tests in the solution
+    - name: Execute unit tests
+      run: dotnet test
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+    - name: test
+      run: dir
+
+    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
+    #- name: Upload build artifacts
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    name: MSIX Package
+    #    path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,42 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
-# built on .NET Core.
-# To learn how to migrate your existing application to .NET Core,
-# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
-#
-# To configure this workflow:
-#
-# 1. Configure environment variables
-# GitHub sets default environment variables for every workflow run.
-# Replace the variables relative to your project in the "env" section below.
-#
-# 2. Signing
-# Generate a signing certificate in the Windows Application
-# Packaging Project or add an existing signing certificate to the project.
-# Next, use PowerShell to encode the .pfx file using Base64 encoding
-# by running the following Powershell script to generate the output string:
-#
-# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
-# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
-#
-# Open the output file, SigningCertificate_Encoded.txt, and copy the
-# string inside. Then, add the string to the repo as a GitHub secret
-# and name it "Base64_Encoded_Pfx."
-# For more information on how to configure your signing certificate for
-# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
-#
-# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
-# See "Build the Windows Application Packaging project" below to see how the secret is used.
-#
-# For more information on GitHub Actions, refer to https://github.com/features/actions
-# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
-# refer to https://github.com/microsoft/github-actions-for-desktop-apps
-
-name: .NET Build
+name: Build KitchenLib for Workshop
 
 on:
   push:
@@ -50,48 +12,66 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [Release]
+        configuration: [Workshop]
 
     runs-on: windows-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
       Solution_Name: KitchenLib.sln                        # Replace with your solution name, i.e. MyWpfApp.sln.
-      Test_Project_Path: KitchenLib.TestMod\KitchenLib.TestMod.csproj                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      #Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
-      #Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+      Test_Project_Path: KitchenLib.TestMod/KitchenLib.TestMod.csproj                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
 
     steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
-    # Install the .NET Core workload
+         
+    - name: Setup DepotDownloader
+      run: |
+         Invoke-WebRequest https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.5.0/DepotDownloader-windows-x64.zip -OutFile out.zip
+         7z x out.zip
+        
+    - name: Generate auth code
+      id: generate
+      uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
+      with:
+        shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
+        
+    - name: Download PlateUp Files
+      run: |
+         "${{ steps.generate.outputs.code }}" | .\DepotDownloader.exe -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }}
+         
+     # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
-
+        dotnet-version: |
+         5.0.x
+         
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
-
+      
     # Execute all unit tests in the solution
-    - name: Execute unit tests
-      run: dotnet test
+    #- name: Execute unit tests
+    #  run: dotnet test
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+    - name: Build the application
+      run: |
+        $id = ls -Directory -Name $PWD/depots/1599601/
+        ls $PWD/depots/1599601/$id/PlateUp
+        msbuild $env:Solution_Name -r /p:Configuration=$env:Configuration /p:EnableModDeployLocal='true' /p:GamePath=$PWD/depots/1599601/$id/PlateUp
       env:
         Configuration: ${{ matrix.configuration }}
     - name: test
-      run: dir
+      run: ls ./KitchenLib/content/
 
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
-    #- name: Upload build artifacts
-    #  uses: actions/upload-artifact@v3
-    #  with:
-    #    name: MSIX Package
-    #    path: ${{ env.Wap_Project_Directory }}\AppPackages
+    # Upload the build artifacts for later use
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Workshop Build
+        path: KitchenLib/content/
+        if-no-files-found: error

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         dotnet --list-sdks
         ls -d $PWD/depots/1599601/**
-        dotnet build -c $env:Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='true'
+        dotnet build -c $Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='true'
       env:
         Configuration: ${{ matrix.configuration }}
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
          wget https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.5.0/DepotDownloader-linux-x64.zip
          unzip DepotDownloader-linux-x64.zip
+         chmod +x DepotDownloader
         
     - name: Generate auth code
       id: generate

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -34,7 +34,7 @@ jobs:
         
     - name: Download PlateUp Files
       run: |
-          DepotDownloader -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }} <<< "${{ steps.generate.outputs.code }}"
+          ./DepotDownloader -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }} <<< "${{ steps.generate.outputs.code }}"
          
      # Install the .NET Core workload
     - name: Install .NET Core

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  build:
+  build-and-sign:
 
     strategy:
       matrix:
@@ -14,6 +14,10 @@ jobs:
 
     runs-on: ubuntu-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    permissions:
+      contents: read
+      id-token: write # needed for signing the images with GitHub OIDC Token
 
     steps:
     - name: Checkout
@@ -68,6 +72,15 @@ jobs:
         dotnet build -c $Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='true'
       env:
         Configuration: ${{ matrix.configuration }}
+
+    - name: cosign-installer
+      uses: sigstore/cosign-installer@v3.1.1
+
+    # This performs signing with the Gitub OIDC token. See https://docs.sigstore.dev/cosign/overview/ for specifics
+    - name: Sign with Github Key
+      run: |
+        cosign sign-blob --yes ./KitchenLib/content/KitchenLib-Workshop.dll --bundle ./KitchenLib/content/cosign.bundle
+
 
     - name: Print Directory Contents
       run: ls ./KitchenLib/content/

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -2,9 +2,7 @@ name: Build KitchenLib for Workshop
 
 on:
   push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    branches: [ "development" ]
 
 jobs:
 
@@ -14,12 +12,8 @@ jobs:
       matrix:
         configuration: [Workshop]
 
-    runs-on: windows-latest  # For a list of available runner types, refer to
+    runs-on: ubuntu-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-
-    env:
-      Solution_Name: KitchenLib.sln                        # Replace with your solution name, i.e. MyWpfApp.sln.
-      Test_Project_Path: KitchenLib.TestMod/KitchenLib.TestMod.csproj                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
 
     steps:
     - name: Checkout
@@ -29,8 +23,8 @@ jobs:
          
     - name: Setup DepotDownloader
       run: |
-         Invoke-WebRequest https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.5.0/DepotDownloader-windows-x64.zip -OutFile out.zip
-         7z x out.zip
+         wget https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.5.0/DepotDownloader-linux-x64.zip
+         unzip DepotDownloader-linux-x64.zip
         
     - name: Generate auth code
       id: generate
@@ -40,32 +34,41 @@ jobs:
         
     - name: Download PlateUp Files
       run: |
-         "${{ steps.generate.outputs.code }}" | .\DepotDownloader.exe -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }}
+          DepotDownloader -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }} <<< "${{ steps.generate.outputs.code }}"
          
      # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-         5.0.x
+         6.x
          
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+    #- name: Setup MSBuild.exe
+    #  uses: microsoft/setup-msbuild@v1.0.2
       
     # Execute all unit tests in the solution
     #- name: Execute unit tests
     #  run: dotnet test
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
+    # - name: Build the application
+    #   run: |
+    #     $id = ls -Directory -Name $PWD/depots/1599601/
+    #     ls $PWD/depots/1599601/$id/PlateUp
+    #     msbuild $env:Solution_Name -r /p:Configuration=$env:Configuration /p:EnableModDeployLocal='true' /p:GamePath=$PWD/depots/1599601/$id/PlateUp
+    #   env:
+    #     Configuration: ${{ matrix.configuration }}
+
     - name: Build the application
       run: |
-        $id = ls -Directory -Name $PWD/depots/1599601/
-        ls $PWD/depots/1599601/$id/PlateUp
-        msbuild $env:Solution_Name -r /p:Configuration=$env:Configuration /p:EnableModDeployLocal='true' /p:GamePath=$PWD/depots/1599601/$id/PlateUp
+        dotnet --list-sdks
+        ls -d $PWD/depots/1599601/**
+        dotnet build -c $env:Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='true'
       env:
         Configuration: ${{ matrix.configuration }}
-    - name: test
+
+    - name: Print Directory Contents
       run: ls ./KitchenLib/content/
 
     # Upload the build artifacts for later use

--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -19,7 +19,8 @@
 		<None Include="..\.editorconfig" Link=".editorconfig" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup>  
+	  <PackageReference Include="Lib.Harmony" Version="2.2.2" />
 	  <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	  <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.8.3" />
 	  <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />

--- a/KitchenLib/src/Utils/MaterialUtils.cs
+++ b/KitchenLib/src/Utils/MaterialUtils.cs
@@ -253,9 +253,11 @@ namespace KitchenLib.Utils
         /// <returns>The requested material or null if not found.</returns>
         public static Material GetCustomMaterial(string materialName)
 		{
-            Material mat;
-			bool KeyNotFoundException = CustomMaterials.CustomMaterialsIndex.TryGetValue(materialName, out mat);
-            return mat;
+			bool found = CustomMaterials.CustomMaterialsIndex.ContainsKey(materialName);
+            if(found)
+                return CustomMaterials.CustomMaterialsIndex[materialName];
+            else
+                return null;
         }
 
         /// <summary>

--- a/KitchenLib/src/Utils/MaterialUtils.cs
+++ b/KitchenLib/src/Utils/MaterialUtils.cs
@@ -253,7 +253,9 @@ namespace KitchenLib.Utils
         /// <returns>The requested material or null if not found.</returns>
         public static Material GetCustomMaterial(string materialName)
 		{
-			return CustomMaterials.CustomMaterialsIndex.GetValueOrDefault(materialName);
+            Material mat;
+			bool KeyNotFoundException = CustomMaterials.CustomMaterialsIndex.TryGetValue(materialName, out mat);
+            return mat;
         }
 
         /// <summary>

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+echo "Uploading to steam workshop"
+
+cat << EOF > $PWD/workshop.vdf
+"workshopitem"
+{
+  "appid" "${INPUT_APPID}"
+  "contentfolder" "${GITHUB_WORKSPACE}/${INPUT_PATH}"
+  "changenote" "Automatic upload from Github Actions"
+  "publishedfileid" "${INPUT_ITEMID}"
+}
+EOF
+
+echo "$(cat $PWD/workshop.vdf)"
+
+if [[ -z "${STEAM_CODE}" ]]; then
+  steamcmd +@ShutdownOnFailedCommand 1 +login "${STEAM_USERNAME}" "${STEAM_PASSWORD}" +workshop_build_item ${PWD}/workshop.vdf +quit
+else
+  steamcmd +@ShutdownOnFailedCommand 1 +login "${STEAM_USERNAME}" "${STEAM_PASSWORD}" ${STEAM_CODE} +workshop_build_item ${PWD}/workshop.vdf +quit
+fi


### PR DESCRIPTION
So this looks to be about what we discussed for a steam workshop workflow upload as well. Example using my own testing mod id: https://github.com/Rich7690/KitchenLib/actions/runs/5480086576/jobs/9982802579

The way it works currently is that it does a rebuild on every push to `development` or `master` branches. Additionally, one can trigger a workflow manually using the `workflow_dispatch` button and you pick which mod id you want to upload to steam workshop (currently included are KitchenLib/Beta and my testing mod id).

## Secrets Required

`STEAM_USERNAME` - Username to use to log into steam
`STEAM_PASSWORD` - Password to log into steam
`STEAM_SHARED_SECRET` - This is the steam 2FA shared secret used to generate TOTP codes to login. Best way I've found is to use https://github.com/Jessecar96/SteamDesktopAuthenticator to setup a desktop Authenticator and grab the shared secret from the file created. **NOTE:** We need to be very careful with this secret to be sure we don't expose it accidentally. Github Actions itself prevents from printing it out, but one needs to make sure code doesn't get merged to the workflow that exposes it.




![WorkflowDispatch](https://github.com/KitchenMods/KitchenLib/assets/11451714/9275e677-9b20-4e56-b644-36cdb597fab0)
