### PR TITLE
CI Workflow Implementation

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -2,6 +2,17 @@ name: Build and Sign
 
 on:
   workflow_dispatch:
+    inputs:
+      releaseversion:
+        description: 'The release version'
+        required: true
+        default: ''
+        type: string
+      betaversion:
+        description: 'The beta version'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build-and-sign:
@@ -96,3 +107,28 @@ jobs:
         name: KitchenLib-Build
         path: KitchenLib/content/
         if-no-files-found: error
+
+    # Publish Release
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ github.event.inputs.releaseversion }}${{ github.event.inputs.betaversion }}
+        release_name: ${{ github.event.inputs.releaseversion }}${{ github.event.inputs.betaversion }}
+        body_path: ./KitchenLib/Changelogs/${{ github.event.inputs.releaseversion }}/Github/v${{ github.event.inputs.releaseversion }}${{ github.event.inputs.betaversion }}.MD
+        draft: false
+        prerelease: ${{ !(github.event.inputs.betaversion == '') }}
+          
+    # Upload Release Files
+    - name: Upload Release Files
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: build/KitchenLib-Build.zip
+        asset_name: KitchenLib-v${{ github.event.inputs.releaseversion }}${{ github.event.inputs.betaversion }}}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -1,0 +1,98 @@
+name: Upload to Workshop
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-sign:
+    strategy:
+      matrix:
+        configuration: [Workshop]
+
+    runs-on: ubuntu-latest  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    permissions:
+      contents: read
+      id-token: write # needed for signing the images with GitHub OIDC Token
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+         
+    - name: Setup DepotDownloader
+      run: |
+         wget https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.5.0/DepotDownloader-linux-x64.zip
+         unzip DepotDownloader-linux-x64.zip
+         chmod +x DepotDownloader
+        
+    - name: Generate auth code
+      id: generate
+      uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
+      with:
+        shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
+
+    - name: Restore Cache
+      id: cache-things-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: depots
+        key: plateup-cache
+        restore-keys: |
+          plateup-cache
+        
+    - name: Download PlateUp Files
+      run: |
+          ./DepotDownloader -app 1599600 -depot 1599601 -username ${{ secrets.STEAM_USERNAME }} -password ${{ secrets.STEAM_PASSWORD }} <<< "${{ steps.generate.outputs.code }}"
+    
+    - name: Save Cache
+      id: cache-things-save
+      uses: actions/cache/save@v3
+      with:
+        path: depots
+        key: plateup-cache-${{ hashFiles('depots/**/*.dll') }}
+
+     # Install the .NET Core workload
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+         6.x
+         
+    # Execute all unit tests in the solution TODO: Implement tests?
+    #- name: Execute unit tests
+    #  run: dotnet test
+
+    - name: Build the application
+      run: |
+        set -x
+        dotnet --list-sdks
+        ls -d $PWD/depots/1599601/**
+        dotnet build -c $Configuration -p:GamePath=`ls -d $PWD/depots/1599601/**`/PlateUp -p:EnableModDeployLocal='false' -p:EnableGameDebugging='false' --os windows --no-self-contained ./KitchenLib/KitchenLib.csproj
+        cp ./KitchenLib/bin/$Configuration/net472/windows-x64/KitchenLib-$Configuration.dll ./KitchenLib/content/
+        cp ./KitchenLib/bin/$Configuration/net472/KitchenLib-$Configuration.xml ./KitchenLib/content/
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    - name: cosign-installer
+      uses: sigstore/cosign-installer@v3.1.1
+
+    # This performs signing with the Gitub OIDC token. See https://docs.sigstore.dev/cosign/overview/ for specifics
+    - name: Sign with Github Key
+      run: |
+        cosign sign-blob --yes ./KitchenLib/content/KitchenLib-Workshop.dll --bundle ./KitchenLib/content/cosign.bundle
+
+    - name: Perform Hashes
+      run: |
+        sha256sum ./KitchenLib/content/* > ./KitchenLib/content/checksums.txt
+        ls ./KitchenLib/content/
+
+    # Upload the build artifacts for later use
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: KitchenLib-Build-${{ github.sha }}
+        path: KitchenLib/content/
+        if-no-files-found: error

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -1,4 +1,4 @@
-name: Upload to Workshop
+name: Build and Sign
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -93,6 +93,6 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: KitchenLib-Build-${{ github.sha }}
+        name: KitchenLib-Build
         path: KitchenLib/content/
         if-no-files-found: error

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -11,7 +11,17 @@ on:
         options:
           - '2898069883' # KitchenLib mod id
           - '2932799348' # KitchenLib Beta mod id
-          - '2999830291' # Testing KitchenLib mod id
+          - '3000699306' # Testing KitchenLib mod id
+      releaseversion:
+        description: 'The release version'
+        required: true
+        default: ''
+        type: string
+      betaversion:
+        description: 'The beta version'
+        required: false
+        default: ''
+        type: string
 
 jobs:
 
@@ -62,3 +72,17 @@ jobs:
         STEAM_USERNAME: '${{ secrets.STEAM_USERNAME }}' # Your Steam username
         STEAM_PASSWORD: '${{ secrets.STEAM_PASSWORD }}' # Your Steam password
         STEAM_CODE: ${{ steps.generate-code.outputs.code }}
+        CHANGELOGVER: ${{ github.event.inputs.releaseversion }}
+        CHANGELOGBETA: ${{ github.event.inputs.betaversion }}
+    
+    - name: Post to Discord
+      run: |
+        pip install discordwebhook
+        python discord.py
+      env:
+        INPUT_PATH: 'build' # Path to your mod's folder from repository root
+        CHANGELOGVER: ${{ github.event.inputs.releaseversion }}
+        CHANGELOGBETA: ${{ github.event.inputs.betaversion }}
+        DISCORDURL: '${{ secrets.DISCORD_WEBHOOK }}'
+
+   

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -32,9 +32,8 @@ jobs:
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2
       with:
-          name: KitchenLib-Build-${{ github.sha }}
-          commit: ${{ github.sha }}
           workflow: build-and-sign.yml
+          branch: $GITHUB_REF_NAME
 
     - name: test
       run: |

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -37,11 +37,11 @@ jobs:
           path: build
           name: KitchenLib-Build
 
-    - name: test
+    - name: List Directory Contents
       run: |
         set -e
         ls -al
-        ls -al build/KitchenLib-Build
+        ls -al build
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@b786e0da44db3d817e66fa3910a9560cb28c9323
@@ -58,7 +58,7 @@ jobs:
       env:
         INPUT_APPID: 1599600 # Game's Steam App ID (PlateUp)
         INPUT_ITEMID: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
-        INPUT_PATH: 'build/KitchenLib-Build' # Path to your mod's folder from repository root
+        INPUT_PATH: 'build' # Path to your mod's folder from repository root
         STEAM_USERNAME: '${{ secrets.STEAM_USERNAME }}' # Your Steam username
         STEAM_PASSWORD: '${{ secrets.STEAM_PASSWORD }}' # Your Steam password
         STEAM_CODE: ${{ steps.generate-code.outputs.code }}

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -34,12 +34,13 @@ jobs:
       with:
           workflow: build-and-sign.yml
           branch: ${{ github.ref_name }}
+          path: content
 
     - name: test
       run: |
         set -e
         ls -al
-        exit 1
+        ls -al content/
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@b786e0da44db3d817e66fa3910a9560cb28c9323
@@ -56,7 +57,7 @@ jobs:
       env:
         INPUT_APPID: 1599600 # Game's Steam App ID (PlateUp)
         INPUT_ITEMID: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
-        INPUT_PATH: 'KitchenLib/content' # Path to your mod's folder from repository root
+        INPUT_PATH: 'content' # Path to your mod's folder from repository root
         STEAM_USERNAME: '${{ secrets.STEAM_USERNAME }}' # Your Steam username
         STEAM_PASSWORD: '${{ secrets.STEAM_PASSWORD }}' # Your Steam password
         STEAM_CODE: ${{ steps.generate-code.outputs.code }}

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -34,13 +34,14 @@ jobs:
       with:
           workflow: build-and-sign.yml
           branch: ${{ github.ref_name }}
-          path: content
+          path: build
+          name: KitchenLib-Build
 
     - name: test
       run: |
         set -e
         ls -al
-        ls -al content/
+        ls -al build/KitchenLib-Build
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@b786e0da44db3d817e66fa3910a9560cb28c9323
@@ -57,7 +58,7 @@ jobs:
       env:
         INPUT_APPID: 1599600 # Game's Steam App ID (PlateUp)
         INPUT_ITEMID: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
-        INPUT_PATH: 'content' # Path to your mod's folder from repository root
+        INPUT_PATH: 'build/KitchenLib-Build' # Path to your mod's folder from repository root
         STEAM_USERNAME: '${{ secrets.STEAM_USERNAME }}' # Your Steam username
         STEAM_PASSWORD: '${{ secrets.STEAM_PASSWORD }}' # Your Steam password
         STEAM_CODE: ${{ steps.generate-code.outputs.code }}

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -1,0 +1,59 @@
+name: Upload to Workshop
+
+on:
+  workflow_dispatch:
+    inputs:
+      itemid:
+        description: 'The steam workshop item id to publish artifacts for'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - '2898069883' # KitchenLib mod id
+          - '2932799348' # KitchenLib Beta mod id
+          - '2999830291' # Testing KitchenLib mod id
+
+jobs:
+
+  upload:
+    runs-on: ubuntu-latest 
+
+    permissions:
+      contents: read
+
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: actions/download-artifact@v3
+      name: Download previous build
+      with:
+          name: KitchenLib-Build-${{ github.sha }}
+
+    - name: test
+      run: |
+        set -e
+        ls -al
+        exit 1
+
+    - name: Setup steamcmd
+      uses: CyberAndrii/setup-steamcmd@b786e0da44db3d817e66fa3910a9560cb28c9323
+
+    - name: Generate auth code
+      id: generate-code
+      uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
+      with:
+        shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
+
+    - name: Upload to steam workshop      run: |
+        ./upload.sh
+      env:
+        INPUT_APPID: 1599600 # Game's Steam App ID (PlateUp)
+        INPUT_ITEMID: ${{ inputs.itemid }} # Your mod's Steam Workshop ID
+        INPUT_PATH: 'KitchenLib/content' # Path to your mod's folder from repository root
+        STEAM_USERNAME: '${{ secrets.STEAM_USERNAME }}' # Your Steam username
+        STEAM_PASSWORD: '${{ secrets.STEAM_PASSWORD }}' # Your Steam password
+        STEAM_CODE: ${{ steps.generate-code.outputs.code }}

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -28,10 +28,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/download-artifact@v3
-      name: Download previous build
+    - name: Download artifact
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v2
       with:
           name: KitchenLib-Build-${{ github.sha }}
+          commit: ${{ github.sha }}
+          workflow: build-and-sign.yml
 
     - name: test
       run: |

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -33,7 +33,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
           workflow: build-and-sign.yml
-          branch: $GITHUB_REF_NAME
+          branch: ${{ github.ref_name }}
 
     - name: test
       run: |

--- a/.github/workflows/workshop-upload.yml
+++ b/.github/workflows/workshop-upload.yml
@@ -48,7 +48,8 @@ jobs:
       with:
         shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
 
-    - name: Upload to steam workshop      run: |
+    - name: Upload to steam workshop      
+      run: |
         ./upload.sh
       env:
         INPUT_APPID: 1599600 # Game's Steam App ID (PlateUp)

--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+	  <PackageReference Include="Harmony" Version="2.10.1" />
 	  <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	  <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.8.3" />
 	  <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />

--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -20,6 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Lib.Harmony" Version="2.2.2" />
 	  <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	  <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.8.3" />
 	  <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />

--- a/KitchenLib/KitchenLib.csproj
+++ b/KitchenLib/KitchenLib.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Harmony" Version="2.10.1" />
+	  <PackageReference Include="HarmonyX" Version="2.10.1" />
 	  <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	  <PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.8.3" />
 	  <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />

--- a/KitchenLib/src/Customs/Materials/CustomMaterials.cs
+++ b/KitchenLib/src/Customs/Materials/CustomMaterials.cs
@@ -20,8 +20,11 @@ namespace KitchenLib.Customs
 
 		public static Material GetCustomMaterial(string materialName)
 		{
-			CustomMaterialsIndex.TryGetValue(materialName, out Material material);
-			return material;
+			bool found = CustomMaterials.CustomMaterialsIndex.ContainsKey(materialName);
+			if (found)
+				return CustomMaterials.CustomMaterialsIndex[materialName];
+			else
+				return null;
 		}
 
 		public static List<Material> GetCustomMaterials()

--- a/KitchenLib/src/Customs/Materials/CustomMaterials.cs
+++ b/KitchenLib/src/Customs/Materials/CustomMaterials.cs
@@ -20,11 +20,8 @@ namespace KitchenLib.Customs
 
 		public static Material GetCustomMaterial(string materialName)
 		{
-			bool found = CustomMaterials.CustomMaterialsIndex.ContainsKey(materialName);
-			if (found)
-				return CustomMaterials.CustomMaterialsIndex[materialName];
-			else
-				return null;
+			CustomMaterialsIndex.TryGetValue(materialName, out Material material);
+			return material;
 		}
 
 		public static List<Material> GetCustomMaterials()

--- a/KitchenLib/src/Utils/MaterialUtils.cs
+++ b/KitchenLib/src/Utils/MaterialUtils.cs
@@ -253,7 +253,11 @@ namespace KitchenLib.Utils
         /// <returns>The requested material or null if not found.</returns>
         public static Material GetCustomMaterial(string materialName)
 		{
-			return CustomMaterials.CustomMaterialsIndex.GetValueOrDefault(materialName);
+			bool found = CustomMaterials.CustomMaterialsIndex.ContainsKey(materialName);
+			if (found)
+				return CustomMaterials.CustomMaterialsIndex[materialName];
+			else
+				return null;
         }
 
         /// <summary>

--- a/discord.py
+++ b/discord.py
@@ -1,0 +1,12 @@
+from discordwebhook import Discord
+import os
+
+with open('KitchenLib/Changelogs/'+os.environ['CHANGELOGVER']+'/Github/v'+os.environ['CHANGELOGVER']+os.environ['CHANGELOGBETA']+'.MD', 'r', encoding='utf-8-sig') as file:
+    data = file.read()
+
+discord = Discord(url=os.environ['DISCORDURL'])
+if (os.environ['CHANGELOGBETA'] == ""):
+    discord.post(content='***KitchenLib v'+os.environ['CHANGELOGVER']+'***\nhttps://github.com/KitchenMods/KitchenLib/releases/tag/v'+os.environ['CHANGELOGVER']+'\n\n'+data+'\n\n<@&1028210506537893918>')
+else:
+    discord.post(content='***KitchenLib Beta v'+os.environ['CHANGELOGVER']+os.environ['CHANGELOGBETA']+'***\nhttps://github.com/KitchenMods/KitchenLib/releases/tag/v'+os.environ['CHANGELOGVER']+os.environ['CHANGELOGBETA']+'\n\n'+data+'\n\n<@&1074702337479815249>')
+

--- a/upload.sh
+++ b/upload.sh
@@ -3,12 +3,15 @@ set -e
 
 echo "Uploading to steam workshop"
 
+steammessage=`cat KitchenLib/Changelogs/${CHANGELOGVER}/Workshop/v${CHANGELOGVER}${CHANGELOGBETA}.MD`
+export Cleaned_steammessage=$(echo "$steammessage" | tr '"' ' ')
+
 cat << EOF > $PWD/workshop.vdf
 "workshopitem"
 {
   "appid" "${INPUT_APPID}"
   "contentfolder" "${GITHUB_WORKSPACE}/${INPUT_PATH}"
-  "changenote" "Automatic upload from Github Actions"
+  "changenote" "${Cleaned_steammessage}"
   "publishedfileid" "${INPUT_ITEMID}"
 }
 EOF

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+echo "Uploading to steam workshop"
+
+cat << EOF > $PWD/workshop.vdf
+"workshopitem"
+{
+  "appid" "${INPUT_APPID}"
+  "contentfolder" "${GITHUB_WORKSPACE}/${INPUT_PATH}"
+  "changenote" "Automatic upload from Github Actions"
+  "publishedfileid" "${INPUT_ITEMID}"
+}
+EOF
+
+echo "$(cat $PWD/workshop.vdf)"
+
+if [[ -z "${STEAM_CODE}" ]]; then
+  steamcmd +@ShutdownOnFailedCommand 1 +login "${STEAM_USERNAME}" "${STEAM_PASSWORD}" +workshop_build_item ${PWD}/workshop.vdf +quit
+else
+  steamcmd +@ShutdownOnFailedCommand 1 +login "${STEAM_USERNAME}" "${STEAM_PASSWORD}" ${STEAM_CODE} +workshop_build_item ${PWD}/workshop.vdf +quit
+fi


### PR DESCRIPTION
Splits up the proposed workflow in https://github.com/KitchenMods/KitchenLib/pull/73 to a "Build and Sign" which just performs compilation and signing and a "Upload to Workshop" workflow which uploads the artifacts to Steam when run. All workflows are run manually. Same requirements apply as the original PR.