### PR TITLE
Fix assignment

### DIFF
--- a/KitchenLib/src/Systems/ModUpdateManager.cs
+++ b/KitchenLib/src/Systems/ModUpdateManager.cs
@@ -72,7 +72,7 @@ namespace KitchenLib.Systems
                 mod => mod,
                 mod => mod.GetPacks<AssemblyModPack>()
                           .SelectMany(modPack => ((List<IModInitializer>)fInitializers.GetValue(modPack))
-                               .Where(m => m is BaseMod)
+                               .Where(m => m.GetType().BaseType.IsAssignableFrom(typeof(BaseMod)))
                                .Select(m => (BaseMod)m))
                           .ToList()
             );


### PR DESCRIPTION
The is operator is used to compare derived types to a base type. The operand in this case is of the type IModInitializer so we have to use a different method. Types do contain a reference to the basetype which should work for our purposes.