### PR TITLE
RegisterGameDataObjects Function

### DIFF
--- a/KitchenLib/src/BaseMod.cs
+++ b/KitchenLib/src/BaseMod.cs
@@ -352,7 +352,7 @@ namespace KitchenLib
 			Assembly asm = ModRegistery.keyValuePairs[t];
 			foreach (Type type in asm.GetTypes())
 			{
-				if(typeof(IAddGameData).IsAssignableFrom(type))
+				if(typeof(IAddGDO).IsAssignableFrom(type))
 				{
 					keyValuePairs.Add(type.Name, AddGameDataObject(type));
 				}

--- a/KitchenLib/src/BaseMod.cs
+++ b/KitchenLib/src/BaseMod.cs
@@ -354,7 +354,6 @@ namespace KitchenLib
 			{
 				if(typeof(IAddGameData).IsAssignableFrom(type))
 				{
-					Main.Logger.LogWarning("THIS IS IMPORTANT: " + type.FullName);
 					keyValuePairs.Add(type.Name, AddGameDataObject(type));
 				}
 			}

--- a/KitchenLib/src/Customs/IAddGameData.cs
+++ b/KitchenLib/src/Customs/IAddGameData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenLib.Customs
+{
+	public interface IAddGameData
+	{
+
+	}
+}

--- a/KitchenLib/src/Customs/IAddGameData.cs
+++ b/KitchenLib/src/Customs/IAddGameData.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace KitchenLib.Customs
+﻿namespace KitchenLib.Customs
 {
-	public interface IAddGameData
+	public interface IAddGDO
 	{
 
 	}


### PR DESCRIPTION
Adds IAddGDO interface used to tag custom gdos.

Adds RegisterGameDataObjects(Type t) which when passed a mod's type, will register all of their game data objects marked with IAddGDO.

Adds AddGameDataObject(Type t) for adding game data objects based on a type.