### PR TITLE
Made singleton gdotypes collection obsolete

### DIFF
--- a/src/Customs/CustomGDO.cs
+++ b/src/Customs/CustomGDO.cs
@@ -1,12 +1,16 @@
+using KitchenData;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace KitchenLib.Customs
 {
     public class CustomGDO
 	{
 		public static Dictionary<int, CustomGameDataObject> GDOs = new Dictionary<int, CustomGameDataObject>();
-		public static Dictionary<Type, CustomGameDataObject> GDOsByType = new Dictionary<Type, CustomGameDataObject>();
+		[Obsolete("This collection creates a singleton design class pattern. Use GDOTypeInstances collection. Only purpose now is the public access to the collection might be used by mods")]
+		public static Dictionary<Type, CustomGameDataObject> GDOsByType = new Dictionary<Type, CustomGameDataObject>(); //TODO: Move towards removing this by creating a getter for a virtual collection
+		public static Dictionary<Type, List<CustomGameDataObject>> GDOTypeInstances = new Dictionary<Type, List<CustomGameDataObject>>();
 		public static Dictionary<KeyValuePair<string, string>, CustomGameDataObject> GDOsByGUID = new Dictionary<KeyValuePair<string, string>, CustomGameDataObject>();
 		public static Dictionary<KeyValuePair<string, string>, CustomGameDataObject> GDOsByModName = new Dictionary<KeyValuePair<string, string>, CustomGameDataObject>();
 		public static Dictionary<int, CustomGameDataObject> GDOsByLegacyID = new Dictionary<int, CustomGameDataObject>();
@@ -23,16 +27,26 @@ namespace KitchenLib.Customs
 			{
 				Main.LogInfo($"Error while registering custom GDO of type {gdo.GetType().FullName} with ID={gdo.ID} and Name=\"{gdo.ModName}:{gdo.UniqueNameID}\". Double-check to ensure that the UniqueNameID is actually unique. (Clashing with : {GDOs[gdo.ID]})");
 				return null;
-			}
-
+			}			
 			GDOs.Add(gdo.ID, gdo);
 			GDOsByLegacyID.Add(gdo.LegacyID, gdo);
 			LegacyGDOIDs.Add(gdo.LegacyID, gdo.ID);
-			GDOsByType.Add(gdo.GetType(), gdo);
+			if (!GDOsByType.ContainsKey(gdo.GetType())) GDOsByType.Add(gdo.GetType(), gdo); //support legacy collection
+			SafeAddTypeInstance(GDOTypeInstances, gdo);
 			GDOsByGUID.Add(new KeyValuePair<string, string>(gdo.ModID, gdo.UniqueNameID), gdo);
 			GDOsByModName.Add(new KeyValuePair<string, string>(gdo.ModName, gdo.UniqueNameID), gdo);
 
 			return gdo;
+		}
+
+		static void SafeAddTypeInstance(Dictionary<Type,List<CustomGameDataObject>> dictionary, CustomGameDataObject gdo)
+		{
+			if (!dictionary.TryGetValue(gdo.GetType(), out List<CustomGameDataObject> twins))
+			{
+				twins = new List<CustomGameDataObject>();				
+				dictionary.Add(gdo.GetType(), twins);
+			}
+			twins.Add(gdo);
 		}
 	}
 }

--- a/src/Customs/CustomGameDataObjects/CustomItem.cs
+++ b/src/Customs/CustomGameDataObjects/CustomItem.cs
@@ -59,7 +59,12 @@ namespace KitchenLib.Customs
         public virtual GameObject SidePrefab { get; protected set; }
         public virtual string ColourBlindTag { get; protected set; }
         public virtual int RewardOverride { get; protected set; } = -1;
-
+		
+		/// <summary>
+		/// Instantiates a PlateUp Item GameDataObject from this KitchenLib CustomItem
+		/// </summary>
+		/// <param name="gameData">PlateUp GameData</param>
+		/// <param name="gameDataObject">Outputs a PlateUp GDO</param>
         public override void Convert(GameData gameData, out GameDataObject gameDataObject)
         {
             Item result = ScriptableObject.CreateInstance<Item>();
@@ -90,7 +95,7 @@ namespace KitchenLib.Customs
 
 			if (!string.IsNullOrEmpty(ColourBlindTag))
 			{
-				Main.LogError($"Adding ColourBlindTag '{ColourBlindTag}'");
+				Main.LogWarning($"Adding ColourBlindTag '{ColourBlindTag}'");
 				Item steak = (Item)GDOUtils.GetExistingGDO(ItemReferences.SteakMedium);
 				if (steak != null)
 				{
@@ -110,6 +115,11 @@ namespace KitchenLib.Customs
 			gameDataObject = result;
         }
 
+		/// <summary>
+		/// Initialializes a PlateUp GDO Item with optional properties.
+		/// </summary>
+		/// <param name="gameData">PlateUp GameData</param>
+		/// <param name="gameDataObject">The GDO to set properties on</param>
         public override void AttachDependentProperties(GameData gameData, GameDataObject gameDataObject)
         {
             Item result = (Item)gameDataObject;
@@ -132,7 +142,7 @@ namespace KitchenLib.Customs
             
             if (SidePrefab == null)
             {
-	            Main.LogError($"Assigning fallback side prefab");
+	            Main.LogWarning($"Assigning fallback side prefab");
 	            SidePrefab = result.Prefab ?? Main.bundle.LoadAsset<GameObject>("Error_Item");
             }
             if (result.Prefab == null)

--- a/src/Utils/GDOUtils.cs
+++ b/src/Utils/GDOUtils.cs
@@ -1,5 +1,6 @@
 using KitchenData;
 using KitchenLib.Customs;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -51,10 +52,17 @@ namespace KitchenLib.Utils
 			return result;
 		}
 
+		[Obsolete("Use GDOTypeInstances collection to fetch the first instance of a type.")]
 		public static CustomGameDataObject GetCustomGameDataObject<T>()
+		{			
+			CustomGDO.GDOTypeInstances.TryGetValue(typeof(T), out var result);
+			return result != null ? result.FirstOrDefault() : null;
+		}
+
+		public static List<CustomGameDataObject> GetCustomDataObjectTypeTwins<T>()
 		{
-			CustomGDO.GDOsByType.TryGetValue(typeof(T), out var result);
-			return result;
+			CustomGDO.GDOTypeInstances.TryGetValue(typeof(T), out var result);
+			if (result != null) return result; else return new List<CustomGameDataObject>();
 		}
 
 		public static T GetCastedGDO<T, C>() where T : GameDataObject where C : CustomGameDataObject


### PR DESCRIPTION
This change adds support for multiple instances of a custom game object to avoid a lot of duplicated code in mods